### PR TITLE
Add the 'two_factor_provider_for_user' filter

### DIFF
--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -88,7 +88,7 @@ class Two_Factor_Core {
 		 * @param string $provider The provider currently being used.
 		 * @param int    $user_id  The user ID.
 		 */
-		$provider = apply_filters( 'two_factor_provider_for_user', $provider, $user_id );
+		$provider = apply_filters( 'two_factor_primary_provider_for_user', $provider, $user_id );
 
 		if ( isset( $providers[ $provider ] ) ) {
 			return $providers[ $provider ];

--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -82,6 +82,14 @@ class Two_Factor_Core {
 		$provider = get_user_meta( $user_id, self::PROVIDER_USER_META_KEY, true );
 		$providers = self::get_providers();
 
+		/**
+		 * Filter the two-factor authentication provider used for this user.
+		 *
+		 * @param string $provider The provider currently being used.
+		 * @param int    $user_id  The user ID.
+		 */
+		$provider = apply_filters( 'two_factor_provider_for_user', $provider, $user_id );
+
 		if ( isset( $providers[ $provider ] ) ) {
 			return $providers[ $provider ];
 		}


### PR DESCRIPTION
This filter, added to `Two_Factor_Core::get_provider_for_user()` serves two purposes:

1. Enables developers to set a default two-factor provider (e.g. "if the user hasn't explicitly made a decision default to `$provider`")
2. Enables developers to **force** a specific method when necessary.