### PR TITLE
Correct Proper Noun Notation

### DIFF
--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -36,7 +36,7 @@ class Two_Factor_Core {
 		$providers = array(
 			'Two_Factor_Email'    => TWO_FACTOR_DIR . 'providers/class.two-factor-email.php',
 			'Two_Factor_Totp'     => TWO_FACTOR_DIR . 'providers/class.two-factor-totp.php',
-			'Two_Factor_Fido_U2f' => TWO_FACTOR_DIR . 'providers/class.two-factor-fido-u2f.php',
+			'Two_Factor_FIDO_U2F' => TWO_FACTOR_DIR . 'providers/class.two-factor-fido-u2f.php',
 			'Two_Factor_Dummy'    => TWO_FACTOR_DIR . 'providers/class.two-factor-dummy.php',
 		);
 

--- a/providers/class.two-factor-fido-u2f.php
+++ b/providers/class.two-factor-fido-u2f.php
@@ -1,6 +1,6 @@
 <?php
 
-class Two_Factor_Fido_U2f extends Two_Factor_Provider {
+class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 
 	static function get_instance() {
 		static $instance;
@@ -12,7 +12,7 @@ class Two_Factor_Fido_U2f extends Two_Factor_Provider {
 	}
 
 	function get_label() {
-		return _x( 'FIDO U2f', 'Provider Label', 'two-factor' );
+		return _x( 'FIDO U2F', 'Provider Label', 'two-factor' );
 	}
 
 	function authentication_page( $user ) {}


### PR DESCRIPTION
All characters of "FIDO U2F" is capitalized in FIDO website.