### PR TITLE
Adds Backup Codes Provider

### DIFF
--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -27,10 +27,11 @@ class Two_Factor_Core {
 	 */
 	public static function get_providers() {
 		$providers = array(
-			'Two_Factor_Email'    => TWO_FACTOR_DIR . 'providers/class.two-factor-email.php',
-			'Two_Factor_Totp'     => TWO_FACTOR_DIR . 'providers/class.two-factor-totp.php',
-			'Two_Factor_FIDO_U2F' => TWO_FACTOR_DIR . 'providers/class.two-factor-fido-u2f.php',
-			'Two_Factor_Dummy'    => TWO_FACTOR_DIR . 'providers/class.two-factor-dummy.php',
+			'Two_Factor_Email'        => TWO_FACTOR_DIR . 'providers/class.two-factor-email.php',
+			'Two_Factor_Totp'         => TWO_FACTOR_DIR . 'providers/class.two-factor-totp.php',
+			'Two_Factor_FIDO_U2F'     => TWO_FACTOR_DIR . 'providers/class.two-factor-fido-u2f.php',
+			'Two_Factor_Backup_Codes' => TWO_FACTOR_DIR . 'providers/class.two-factor-backup-codes.php',
+			'Two_Factor_Dummy'        => TWO_FACTOR_DIR . 'providers/class.two-factor-dummy.php',
 		);
 
 		/**
@@ -327,7 +328,7 @@ class Two_Factor_Core {
 		if ( ! $user ) {
 			return;
 		}
-		
+
 		$nonce = $_POST['wp-auth-nonce'];
 		if ( true !== self::verify_login_nonce( $user->ID, $nonce ) ) {
 			wp_safe_redirect( get_bloginfo('url') );
@@ -363,7 +364,7 @@ class Two_Factor_Core {
 		if ( isset ( $_REQUEST[ 'rememberme' ] ) && $_REQUEST[ 'rememberme' ] ) {
 			$rememberme = true;
 		}
-		
+
 		wp_set_auth_cookie( $user->ID, $rememberme );
 
 		$redirect_to = apply_filters( 'login_redirect', $_REQUEST['redirect_to'], $_REQUEST['redirect_to'], $user );
@@ -384,10 +385,11 @@ class Two_Factor_Core {
 		$primary_provider = get_user_meta( $user->ID, self::PROVIDER_USER_META_KEY, true );
 		wp_nonce_field( 'user_two_factor_options', '_nonce_user_two_factor_options', false );
 		?>
+		<h3><?php esc_html_e( 'Two-Factor Options', 'two-factor' ); ?></h3>
 		<table class="form-table">
 			<tr>
 				<th>
-					<?php esc_html_e( 'Two-Factor Options', 'two-factor' ); ?>
+					<?php esc_html_e( 'Two-Factor Method', 'two-factor' ); ?>
 				</th>
 				<td>
 					<table class="two-factor-methods-table">
@@ -414,6 +416,7 @@ class Two_Factor_Core {
 				</td>
 			</tr>
 		</table>
+		<?php do_action( 'user_two_factor_options' );?>
 		<?php
 	}
 

--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -51,11 +51,11 @@ class Two_Factor_Core {
 	 */
 	public static function get_providers() {
 		$providers = array(
-			'Two_Factor_Email'    => TWO_FACTOR_DIR . 'providers/class.two-factor-email.php',
-			'Two_Factor_Totp'     => TWO_FACTOR_DIR . 'providers/class.two-factor-totp.php',
-			'Two_Factor_FIDO_U2F' => TWO_FACTOR_DIR . 'providers/class.two-factor-fido-u2f.php',
+			'Two_Factor_Email'        => TWO_FACTOR_DIR . 'providers/class.two-factor-email.php',
+			'Two_Factor_Totp'         => TWO_FACTOR_DIR . 'providers/class.two-factor-totp.php',
+			'Two_Factor_FIDO_U2F'     => TWO_FACTOR_DIR . 'providers/class.two-factor-fido-u2f.php',
 			'Two_Factor_Backup_Codes' => TWO_FACTOR_DIR . 'providers/class.two-factor-backup-codes.php',
-			'Two_Factor_Dummy'    => TWO_FACTOR_DIR . 'providers/class.two-factor-dummy.php',
+			'Two_Factor_Dummy'        => TWO_FACTOR_DIR . 'providers/class.two-factor-dummy.php',
 		);
 
 		/**

--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -416,7 +416,6 @@ class Two_Factor_Core {
 				</td>
 			</tr>
 		</table>
-		<?php do_action( 'after_two_factor_user_options' );?>
 		<?php
 	}
 

--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -27,11 +27,11 @@ class Two_Factor_Core {
 	 */
 	public static function get_providers() {
 		$providers = array(
-			'Two_Factor_Email'        => TWO_FACTOR_DIR . 'providers/class.two-factor-email.php',
-			'Two_Factor_Totp'         => TWO_FACTOR_DIR . 'providers/class.two-factor-totp.php',
-			'Two_Factor_FIDO_U2F'     => TWO_FACTOR_DIR . 'providers/class.two-factor-fido-u2f.php',
+			'Two_Factor_Email'    => TWO_FACTOR_DIR . 'providers/class.two-factor-email.php',
+			'Two_Factor_Totp'     => TWO_FACTOR_DIR . 'providers/class.two-factor-totp.php',
+			'Two_Factor_FIDO_U2F' => TWO_FACTOR_DIR . 'providers/class.two-factor-fido-u2f.php',
 			'Two_Factor_Backup_Codes' => TWO_FACTOR_DIR . 'providers/class.two-factor-backup-codes.php',
-			'Two_Factor_Dummy'        => TWO_FACTOR_DIR . 'providers/class.two-factor-dummy.php',
+			'Two_Factor_Dummy'    => TWO_FACTOR_DIR . 'providers/class.two-factor-dummy.php',
 		);
 
 		/**
@@ -385,11 +385,10 @@ class Two_Factor_Core {
 		$primary_provider = get_user_meta( $user->ID, self::PROVIDER_USER_META_KEY, true );
 		wp_nonce_field( 'user_two_factor_options', '_nonce_user_two_factor_options', false );
 		?>
-		<h3><?php esc_html_e( 'Two-Factor Authentication', 'two-factor' ); ?></h3>
 		<table class="form-table">
 			<tr>
 				<th>
-					<?php esc_html_e( 'Two-Factor Method', 'two-factor' ); ?>
+					<?php esc_html_e( 'Two-Factor Options', 'two-factor' ); ?>
 				</th>
 				<td>
 					<table class="two-factor-methods-table">

--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -385,7 +385,7 @@ class Two_Factor_Core {
 		$primary_provider = get_user_meta( $user->ID, self::PROVIDER_USER_META_KEY, true );
 		wp_nonce_field( 'user_two_factor_options', '_nonce_user_two_factor_options', false );
 		?>
-		<h3><?php esc_html_e( 'Two-Factor Options', 'two-factor' ); ?></h3>
+		<h3><?php esc_html_e( 'Two-Factor Authentication', 'two-factor' ); ?></h3>
 		<table class="form-table">
 			<tr>
 				<th>
@@ -416,7 +416,7 @@ class Two_Factor_Core {
 				</td>
 			</tr>
 		</table>
-		<?php do_action( 'user_two_factor_options' );?>
+		<?php do_action( 'after_two_factor_user_options' );?>
 		<?php
 	}
 

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -31,7 +31,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		}
 		// Only show this if the provider is enabled
 		$enabled_providers = get_user_meta( $user_id, Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY, true );
-		if( ! in_array( 'Two_Factor_Backup_Codes', $enabled_providers ) ) {
+		if( ! in_array( __CLASS__, $enabled_providers ) ) {
 			return;
 		}
 

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -59,7 +59,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 
 		// Exit if we are not out of codes.
 		if ( 0 < self::codes_remaining_for_user( $user ) ) {
-			return;
+		//	return;
 		}
 
 		// Only show when the provider is enabled.
@@ -70,7 +70,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		<div class="error">
 			<p>
 				<span><?php esc_html_e( 'Two-Factor: You are out of backup codes and need to ' ); ?><span>
-				<a href="<?php echo esc_url( get_edit_user_link( $user->ID ) ); ?>#two-factor-backup-codes">regenerate!</a>
+				<a href="<?php echo esc_url( get_edit_user_link( $user->ID ) . '#two-factor-backup-codes' ); ?>">regenerate!</a>
 			</p>
 		</div>
 		<?php

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -144,21 +144,19 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 						url: ajaxurl,
 						data: {
 							action: 'two_factor_backup_codes_generate',
+							user_id: '<?php echo esc_js( $user_id ); ?>',
 							nonce: '<?php echo esc_js( $ajax_nonce ); ?>'
 						},
 						dataType: 'JSON',
 						success: function( data ) {
 							$( '.two-factor-backup-codes-wrapper' ).show();
 							$( '.two-factor-backup-codes-unused-codes' ).html( '' );
-							$.each( data, function( key, val ) {
+
+							$.each( data.data, function( key, val ) {
 								$( '.two-factor-backup-codes-unused-codes' ).append( '<li>' + val + '</li>' );
 							} );
 							// Update counter.
 							$( '.two-factor-backup-codes-count' ).html( data.length );
-						},
-						error: function( errorThrown ) {
-							alert( 'error' ); // @todo: remove for production
-							console.log( errorThrown );
 						}
 					} );
 				} );
@@ -198,10 +196,9 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 */
 	public function ajax_generate_json() {
 		check_ajax_referer( 'two-factor-backup-codes-generate-json', 'nonce' );
-
-		$user_id = get_current_user_id();
+		$user_id = sanitize_text_field( $_REQUEST['user_id'] );
 		$codes = $this->generate_codes( $user_id );
-		wp_send_json( $codes );
+		wp_send_json_success( $codes );
 	}
 
 	/**

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -1,0 +1,218 @@
+<?php
+
+class Two_Factor_Backup_Codes extends Two_Factor_Provider {
+
+	const DEBUG = true;
+	const BACKUP_CODES_META_KEY = '_two_factor_backup_codes';
+	const BACKUP_CODES_DEBUG_META_KEY = '_two_factor_backup_codes_debug';
+	const NUMBER_OF_CODES = 10;
+
+	static function get_instance() {
+		static $instance;
+		$class = __CLASS__;
+		if ( ! is_a( $instance, $class ) ) {
+			$instance = new $class;
+		}
+		return $instance;
+	}
+
+	public static function add_hooks() {
+		$user_id = get_current_user_id();
+		$primary_provider = get_user_meta( $user_id, Two_Factor_Core::PROVIDER_USER_META_KEY, true );
+
+		// Only do these things when Backup Codes are selected as the primary provider.
+		if( 'Two_Factor_Backup_Codes' != $primary_provider ) {
+			return;
+		}
+
+		add_action( 'admin_notices', array( __CLASS__, 'admin_notices' ) );
+		add_action( 'user_two_factor_options', array( __CLASS__, 'user_two_factor_options' ) );
+
+		add_action( 'wp_ajax_two_factor_backup_codes_generate', array( __CLASS__, 'ajax_two_factor_backup_codes_generate' ) );
+	}
+
+	// @todo add nonce
+	public static function ajax_two_factor_backup_codes_generate() {
+		check_ajax_referer( 'two-factor-backup-codes-generate', 'nonce' );
+
+		$user_id = get_current_user_id();
+		$codes = self::get_instance()->generate_codes( $user_id );
+		$json_codes = json_encode( $codes );
+		echo $json_codes;
+		die(0);
+	}
+
+	public static function admin_notices() {
+		$user_id = get_current_user_id();
+
+		// Only show this notice if we are out of backup codes
+		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
+		if( ! empty( $backup_codes ) ) {
+			return;
+		}
+		?>
+			<div class="error">
+				<p><?php _e( 'Two-Factor: You are out of backup codes and need to <a href="' . get_edit_user_link( $user_id ) . '#two-factor-backup-codes" >regenerate</a>! (debug enabled: codes generated at login)', 'two-factor' ); ?></p>
+			</div>
+		<?php
+	}
+
+	public static function user_two_factor_options() {
+		$user_id = get_current_user_id();
+
+		// Only show this notice if we are out of backup codes
+		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
+		$ajax_nonce = wp_create_nonce( 'two-factor-backup-codes-generate' );
+		?>
+		<table id="two-factor-backup-codes" class="form-table two-factor-backup-codes-table">
+			<tbody>
+				<tr>
+					<th><label><?php esc_html_e( 'Two-Factor Backup Codes', 'two-factor' ); ?></label></th>
+					<td>
+						<p>Two-Factor Backup Verification Codes are single use codes that can be used to login.</p>
+						<p></p>
+						<button type="button" class="button button-two-factor-backup-codes-generate button-secondary hide-if-no-js">Generate Verification Codes</button>
+						<p class="description"><span class="two-factor-backup-codes-count"><?php echo count( $backup_codes ); ?></span> unused codes remaining.</p>
+						<div class="two-factor-backup-codes-wrapper" style="display:none;">
+							<ol class="two-factor-backup-codes-unused-codes"></ol>
+							<p class="description">Write 'em down y'all!</p>
+						</div>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+		<script type="text/javascript">
+			jQuery(document).ready(function($) {
+				$('.button-two-factor-backup-codes-generate').click( function() {
+					jQuery.ajax({
+						url: ajaxurl,
+						data:{
+							action:'two_factor_backup_codes_generate',
+							nonce: '<?php echo $ajax_nonce; ?>',
+						},
+						dataType: 'JSON',
+						success:function(data){
+							$('.two-factor-backup-codes-wrapper').show();
+							$('.two-factor-backup-codes-unused-codes').html('');
+							$.each( data, function( key, val ) {
+								$('.two-factor-backup-codes-unused-codes').append('<li>'+val+'</li>');
+							});
+							// Update counter
+							$('.two-factor-backup-codes-count').html( data.length );
+						},
+						error: function(errorThrown){
+							alert('error');
+							console.log(errorThrown);
+						}
+					});
+				});
+			});
+		</script>
+		<?php
+	}
+
+	function get_label() {
+		return _x( 'Backup Verification Codes (Single Use)', 'Provider Label', 'two-factor' );
+	}
+
+	function validate_code( $user_id, $code ) {
+		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
+
+		foreach( $backup_codes as $code_index => $backup_code ) {
+			if( wp_check_password( $code, $backup_code, $user_id ) ) {
+				// Backup Codes are single use and are deleted upon a successful validation
+				$this->delete_code( $user_id, $code_index );
+				$this->delete_code_debug( $user_id, $code ); //@todo delete
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private function delete_code( $user_id, $code_index ) {
+		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
+
+		// delete the current code from the list since it's been used.
+		unset( $backup_codes[ $code_index ] );
+		$backup_codes = array_values( $backup_codes );
+
+		// Update the backup code master list
+		update_user_meta( $user_id, self::BACKUP_CODES_META_KEY, $backup_codes );
+	}
+
+	// @todo delete for production
+	private function delete_code_debug( $user_id, $code ) {
+		$backup_codes_debug = get_user_meta( $user_id, self::BACKUP_CODES_DEBUG_META_KEY, true );
+
+		// delete the current code from the list since it's been used.
+		$backup_codes_debug = array_flip( $backup_codes_debug );
+		unset( $backup_codes_debug[ $code ] );
+		$backup_codes_debug = array_flip( $backup_codes_debug );
+		$backup_codes_debug = array_values( $backup_codes_debug );
+
+		// Update the backup code master list
+		update_user_meta( $user_id, self::BACKUP_CODES_DEBUG_META_KEY, $backup_codes_debug );
+	}
+
+	// @todo delete for production
+	function generate_codes_debug( $user_id ) {
+		$codes = array();
+		$codes_debug = array();
+		$codes[] = wp_hash_password( '31337' );
+		$codes_debug[] = '31337';
+
+		update_user_meta( $user_id, self::BACKUP_CODES_META_KEY, $codes );
+		update_user_meta( $user_id, self::BACKUP_CODES_DEBUG_META_KEY, $codes_debug );
+
+		return $codes;
+	}
+
+	// @todo delete for production
+	function display_codes_debug( $user ) {
+
+		echo '<p>Debug: Cheat Sheet</p>';
+
+		$codes_hashed = get_user_meta( $user->ID, self::BACKUP_CODES_META_KEY, true );
+		if( empty( $codes_hashed ) ) {
+			$codes = $this->generate_codes( $user->ID );
+		} else {
+			$codes = get_user_meta( $user->ID, self::BACKUP_CODES_DEBUG_META_KEY, true );
+		}
+		foreach( $codes as $i => $code ) echo "$i.) $code</br>";
+	}
+
+	function generate_codes( $user_id ) {
+		// Create 10 Codes
+		$codes = array();
+		$codes_hashed = array();
+		for( $i = 0; $i < self::NUMBER_OF_CODES; $i++ ) {
+			$code = $this->get_code();
+			$codes_hashed[] = wp_hash_password( $code );
+			$codes[] = $code;
+			unset( $code );
+		}
+
+		update_user_meta( $user_id, self::BACKUP_CODES_META_KEY, $codes_hashed );
+		update_user_meta( $user_id, self::BACKUP_CODES_DEBUG_META_KEY, $codes );
+		return $codes; //unhashed
+	}
+
+	function authentication_page( $user ) {
+		require_once( ABSPATH .  '/wp-admin/includes/template.php' );
+		?>
+		<p><?php if( self::DEBUG ) $this->display_codes_debug( $user ); //@todo delete ?></p><br/>
+		<p><?php esc_html_e( 'Enter a backup verification code.', 'two-factor' ); ?></p><br/>
+		<p>
+			<label for="authcode"><?php esc_html_e( 'Verification Code:' ); ?></label>
+			<input type="tel" name="two-factor-backup-code" id="authcode" class="input" value="" size="20" pattern="[0-9]*" />
+		</p>
+		<?php
+		submit_button( __( 'Submit', 'two-factor' ) );
+	}
+
+	function validate_authentication( $user ) {
+		return $this->validate_code( $user->ID, $_REQUEST['two-factor-backup-code'] );
+	}
+
+}
+Two_Factor_Backup_Codes::add_hooks();

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -66,7 +66,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		}
 		?>
 		<div class="error">
-			<p><?php echo wp_kses( sprintf( __( 'Two-Factor: You are out of backup codes and need to <a href="%1$s#two-factor-backup-codes" >regenerate</a>!', 'two-factor' ), esc_url( get_edit_user_link( $user_id ) ) ), array(  'a' => array( 'href' => array() ) ) ); ?></p>
+			<p><?php echo wp_kses( sprintf( __( 'Two-Factor: You are out of backup codes and need to <a href="%1$s#two-factor-backup-codes" >regenerate</a>!', 'two-factor' ), esc_url( get_edit_user_link( $user_id ) ) ), array( 'a' => array( 'href' => array() ) ) ); ?></p>
 		</div>
 		<?php
 	}
@@ -123,7 +123,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 			<button type="button" class="button button-two-factor-backup-codes-generate button-secondary hide-if-no-js">
 				<?php esc_html_e( 'Generate Verification Codes', 'two-factor' ); ?>
 			</button>
-			<?php echo wp_kses( sprintf( __( '<span class="two-factor-backup-codes-count">%s</span> unused codes remaining.', 'two-factor' ), count( $backup_codes ) ), array(  'span' => array( 'class' => array() ) ) ); ?>
+			<?php echo wp_kses( sprintf( __( '<span class="two-factor-backup-codes-count">%s</span> unused codes remaining.', 'two-factor' ), count( $backup_codes ) ), array( 'span' => array( 'class' => array() ) ) ); ?>
 		</p>
 		<div class="two-factor-backup-codes-wrapper" style="display:none;">
 			<ol class="two-factor-backup-codes-unused-codes"></ol>

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -201,7 +201,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	public function ajax_generate_json() {
 		$user = get_user_by( 'id', sanitize_text_field( $_REQUEST['user_id'] ) );
 		check_ajax_referer( 'two-factor-backup-codes-generate-json-' . $user->ID, 'nonce' );
-		$codes = $this->generate_codes( $user, array('number' => '1') );
+		$codes = $this->generate_codes( $user );
 		wp_send_json_success( $codes );
 	}
 

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -58,6 +58,11 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		$backup_codes = get_user_meta( $user->ID, self::BACKUP_CODES_META_KEY, true );
 
 		// Exit if we are not out of codes
+		/*
+		if( ! self::is_available_for_user( $user ) ) {
+			return;
+		}
+		*/
 		if( 0 < self::codes_remaining_for_user( $user ) ) {
 			return;
 		}
@@ -94,8 +99,8 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 * @return boolean
 	 */
 	public function is_available_for_user( $user ) {
-		$backup_codes = get_user_meta( $user->ID, self::BACKUP_CODES_META_KEY, true );
-		if ( ! empty( $backup_codes ) ) {
+		// Does this user have available codes?
+		if( 0 < self::codes_remaining_for_user( $user ) ) {
 			return true;
 		}
 		return false;

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -19,7 +19,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	protected function __construct() {
 		add_action( 'two-factor-user-options-' . __CLASS__, array( $this, 'user_options' ) );
 		add_action( 'admin_notices', array( $this, 'admin_notices' ) );
-		add_action( 'after_two_factor_user_options', array( $this, 'user_two_factor_options' ) );
+		add_action( 'after_two_factor_user_options', array( $this, 'after_two_factor_user_options' ) );
 		add_action( 'wp_ajax_two_factor_backup_codes_generate', array( $this, 'ajax_generate_json' ) );
 
 		return parent::__construct();
@@ -56,7 +56,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		<?php
 	}
 
-	public static function user_two_factor_options() {
+	public static function after_two_factor_user_options() {
 		$user_id = get_current_user_id();
 		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
 		$ajax_nonce = wp_create_nonce( 'two-factor-backup-codes-generate-json' );

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -251,9 +251,9 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	public function validate_code( $user_id, $code ) {
 		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
 
-		foreach ( $backup_codes as $code_index => $backup_code ) {
-			if ( wp_check_password( $code, $backup_code, $user_id ) ) {
-				$this->delete_code( $user_id, $code_index );
+		foreach ( $backup_codes as $code_index => $code_hashed ) {
+			if ( wp_check_password( $code, $code_hashed, $user_id ) ) {
+				$this->delete_code( $user_id, $code_hashed );
 				return true;
 			}
 		}
@@ -268,12 +268,13 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 * @param int $user_id    The logged-in user ID.
 	 * @param int $code_index The array index of the backup code.
 	 */
-	public function delete_code( $user_id, $code_index ) {
+	public function delete_code( $user_id, $code_hashed ) {
 		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
+		$backup_codes = array_flip( $backup_codes );
 
 		// Delete the current code from the list since it's been used.
-		unset( $backup_codes[ $code_index ] );
-		$backup_codes = array_values( $backup_codes );
+		unset( $backup_codes[ $code_hashed ] );
+		$backup_codes = array_values( array_flip( $backup_codes ) );
 
 		// Update the backup code master list.
 		update_user_meta( $user_id, self::BACKUP_CODES_META_KEY, $backup_codes );

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -2,9 +2,7 @@
 
 class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 
-	const DEBUG = true;
 	const BACKUP_CODES_META_KEY = '_two_factor_backup_codes';
-	const BACKUP_CODES_DEBUG_META_KEY = '_two_factor_backup_codes_debug';
 	const NUMBER_OF_CODES = 10;
 
 	static function get_instance() {
@@ -19,7 +17,6 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	protected function __construct() {
 		add_action( 'two-factor-user-options-' . __CLASS__, array( $this, 'user_options' ) );
 		add_action( 'admin_notices', array( $this, 'admin_notices' ) );
-		add_action( 'after_two_factor_user_options', array( $this, 'after_two_factor_user_options' ) );
 		add_action( 'wp_ajax_two_factor_backup_codes_generate', array( $this, 'ajax_generate_json' ) );
 
 		return parent::__construct();
@@ -34,7 +31,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		}
 		?>
 			<div class="error">
-				<p><?php _e( 'Two-Factor: You are out of backup codes and need to <a href="' . get_edit_user_link( $user_id ) . '#two-factor-backup-codes" >regenerate</a>! (debug enabled: codes generated at login)', 'two-factor' ); ?></p>
+				<p><?php _e( 'Two-Factor: You are out of backup codes and need to <a href="' . get_edit_user_link( $user_id ) . '#two-factor-backup-codes" >regenerate</a>!', 'two-factor' ); ?></p>
 			</div>
 		<?php
 	}
@@ -52,32 +49,14 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
 		$ajax_nonce = wp_create_nonce( 'two-factor-backup-codes-generate-json' );
 		?>
+		<p>
+			<button type="button" class="button button-two-factor-backup-codes-generate button-secondary hide-if-no-js">Generate Verification Codes</button>
 			<kbd><span class="two-factor-backup-codes-count"><?php echo count( $backup_codes ); ?></span> unused codes remaining.</kbd>
-		<?php
-	}
-
-	public static function after_two_factor_user_options() {
-		$user_id = get_current_user_id();
-		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
-		$ajax_nonce = wp_create_nonce( 'two-factor-backup-codes-generate-json' );
-		?>
-		<table id="two-factor-backup-codes" class="form-table two-factor-backup-codes-table">
-			<tbody>
-				<tr>
-					<th><label><?php esc_html_e( 'Two-Factor Backup Codes', 'two-factor' ); ?></label></th>
-					<td>
-						<p>Two-Factor Backup Verification Codes are single use codes that can be used to login.</p>
-						<p></p>
-						<button type="button" class="button button-two-factor-backup-codes-generate button-secondary hide-if-no-js">Generate Verification Codes</button>
-						<!--<p class="description"><span class="two-factor-backup-codes-count"><?php echo count( $backup_codes ); ?></span> unused codes remaining.</p>-->
-						<div class="two-factor-backup-codes-wrapper" style="display:none;">
-							<ol class="two-factor-backup-codes-unused-codes"></ol>
-							<p class="description">Write 'em down y'all!</p>
-						</div>
-					</td>
-				</tr>
-			</tbody>
-		</table>
+		</p>
+		<div class="two-factor-backup-codes-wrapper" style="display:none;">
+			<ol class="two-factor-backup-codes-unused-codes"></ol>
+			<p class="description">Write 'em down y'all!</p>
+		</div>
 		<script type="text/javascript">
 			jQuery(document).ready(function($) {
 				$('.button-two-factor-backup-codes-generate').click( function() {
@@ -108,22 +87,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		<?php
 	}
 
-	// @todo delete for production
-	function display_codes_debug( $user ) {
-
-		echo '<p>Debug: Cheat Sheet</p>';
-
-		$codes_hashed = get_user_meta( $user->ID, self::BACKUP_CODES_META_KEY, true );
-		if( empty( $codes_hashed ) ) {
-			$codes = $this->generate_codes( $user->ID );
-		} else {
-			$codes = get_user_meta( $user->ID, self::BACKUP_CODES_DEBUG_META_KEY, true );
-		}
-		foreach( $codes as $i => $code ) echo "$i.) $code</br>";
-	}
-
 	function generate_codes( $user_id ) {
-		// Create 10 Codes
 		$codes = array();
 		$codes_hashed = array();
 		for( $i = 0; $i < self::NUMBER_OF_CODES; $i++ ) {
@@ -132,28 +96,12 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 			$codes[] = $code;
 			unset( $code );
 		}
-
 		update_user_meta( $user_id, self::BACKUP_CODES_META_KEY, $codes_hashed );
-		update_user_meta( $user_id, self::BACKUP_CODES_DEBUG_META_KEY, $codes );
 		return $codes; //unhashed
 	}
 
-	// @todo delete for production
-	function generate_codes_debug( $user_id ) {
-		$codes = array();
-		$codes_debug = array();
-		$codes[] = wp_hash_password( '31337' );
-		$codes_debug[] = '31337';
-
-		update_user_meta( $user_id, self::BACKUP_CODES_META_KEY, $codes );
-		update_user_meta( $user_id, self::BACKUP_CODES_DEBUG_META_KEY, $codes_debug );
-
-		return $codes;
-	}
-
-	public static function ajax_generate_json() {
+	function ajax_generate_json() {
 		check_ajax_referer( 'two-factor-backup-codes-generate-json', 'nonce' );
-
 		$user_id = get_current_user_id();
 		$codes = self::get_instance()->generate_codes( $user_id );
 		$json_codes = json_encode( $codes );
@@ -164,7 +112,6 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	function authentication_page( $user ) {
 		require_once( ABSPATH .  '/wp-admin/includes/template.php' );
 		?>
-		<p><?php if( self::DEBUG ) $this->display_codes_debug( $user ); //@todo delete ?></p><br/>
 		<p><?php esc_html_e( 'Enter a backup verification code.', 'two-factor' ); ?></p><br/>
 		<p>
 			<label for="authcode"><?php esc_html_e( 'Verification Code:' ); ?></label>
@@ -185,14 +132,13 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 			if( wp_check_password( $code, $backup_code, $user_id ) ) {
 				// Backup Codes are single use and are deleted upon a successful validation
 				$this->delete_code( $user_id, $code_index );
-				$this->delete_code_debug( $user_id, $code ); //@todo delete
 				return true;
 			}
 		}
 		return false;
 	}
 
-	private function delete_code( $user_id, $code_index ) {
+	function delete_code( $user_id, $code_index ) {
 		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
 
 		// delete the current code from the list since it's been used.
@@ -202,19 +148,4 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		// Update the backup code master list
 		update_user_meta( $user_id, self::BACKUP_CODES_META_KEY, $backup_codes );
 	}
-
-	// @todo delete for production
-	private function delete_code_debug( $user_id, $code ) {
-		$backup_codes_debug = get_user_meta( $user_id, self::BACKUP_CODES_DEBUG_META_KEY, true );
-
-		// delete the current code from the list since it's been used.
-		$backup_codes_debug = array_flip( $backup_codes_debug );
-		unset( $backup_codes_debug[ $code ] );
-		$backup_codes_debug = array_flip( $backup_codes_debug );
-		$backup_codes_debug = array_values( $backup_codes_debug );
-
-		// Update the backup code master list
-		update_user_meta( $user_id, self::BACKUP_CODES_DEBUG_META_KEY, $backup_codes_debug );
-	}
-
 }

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -123,11 +123,11 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 			<button type="button" class="button button-two-factor-backup-codes-generate button-secondary hide-if-no-js">
 				<?php esc_html_e( 'Generate Verification Codes', 'two-factor' ); ?>
 			</button>
-			<?php echo wp_kses( sprintf( __( '<span class="two-factor-backup-codes-count">%s</span> unused codes remaining.', 'two-factor' ), count( $backup_codes ) ), array( 'span' => array( 'class' => array() ) ) ); ?>
+			<?php echo wp_kses( sprintf( _n( '%s unused code remaining.', '%s unused codes remaining.', count( $backup_codes ) ), '<span class="two-factor-backup-codes-count">' . count( $backup_codes ) . '</span>' ), array( 'span' => array( 'class' => array() ) ) ); ?>
 		</p>
 		<div class="two-factor-backup-codes-wrapper" style="display:none;">
 			<ol class="two-factor-backup-codes-unused-codes"></ol>
-			<p class="description"><?php esc_html_e( "Write 'em down y'all!" , 'two-factor' ); ?></p>
+			<p class="description"><?php esc_html_e( "Write 'em down y'all!" ); ?></p>
 		</div>
 		<script type="text/javascript">
 			jQuery(document).ready(function($) {
@@ -135,8 +135,8 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 					jQuery.ajax({
 						url: ajaxurl,
 						data:{
-							action:'two_factor_backup_codes_generate',
-							nonce: '<?php echo esc_js( $ajax_nonce ); ?>',
+							action: 'two_factor_backup_codes_generate',
+							nonce: '<?php echo esc_js( $ajax_nonce ); ?>'
 						},
 						dataType: 'JSON',
 						success:function(data){

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -170,7 +170,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 
 		// Append or replace (default).
 		if ( isset( $args['method'] ) && 'append' === $args['method'] ) {
-			$codes_hashed = get_user_meta( $user->ID, self::BACKUP_CODES_META_KEY, true );
+			$codes_hashed = (array) get_user_meta( $user->ID, self::BACKUP_CODES_META_KEY, true );
 		}
 
 		for ( $i = 0; $i < $num_codes; $i++ ) {

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -58,11 +58,6 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		$backup_codes = get_user_meta( $user->ID, self::BACKUP_CODES_META_KEY, true );
 
 		// Exit if we are not out of codes
-		/*
-		if ( ! self::is_available_for_user( $user ) ) {
-			return;
-		}
-		*/
 		if ( 0 < self::codes_remaining_for_user( $user ) ) {
 			return;
 		}
@@ -74,7 +69,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		?>
 		<div class="error">
 			<p>
-				<span><?php _e( 'Two-Factor: You are out of backup codes and need to ' ); ?><span>
+				<span><?php esc_html_e( 'Two-Factor: You are out of backup codes and need to ' ); ?><span>
 				<a href="<?php echo get_edit_user_link( $user->ID ); ?>#two-factor-backup-codes">regenerate!</a>
 			</p>
 		</div>

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -123,7 +123,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		<script type="text/javascript">
 			jQuery( document ).ready( function( $ ) {
 				$( '.button-two-factor-backup-codes-generate' ).click( function() {
-					jQuery.ajax( {
+					$.ajax( {
 						url: ajaxurl,
 						data: {
 							action: 'two_factor_backup_codes_generate',
@@ -193,7 +193,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 * @since 0.1-dev
 	 */
 	public function ajax_generate_json() {
-		$user = get_user_by( 'id', sanitize_text_field( $_REQUEST['user_id'] ) );
+		$user = get_user_by( 'id', sanitize_text_field( $_GET['user_id'] ) );
 		check_ajax_referer( 'two-factor-backup-codes-generate-json-' . $user->ID, 'nonce' );
 
 		// Setup the return data.
@@ -249,7 +249,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 * @return boolean
 	 */
 	public function validate_authentication( $user ) {
-		return $this->validate_code( $user, $_REQUEST['two-factor-backup-code'] );
+		return $this->validate_code( $user, $_POST['two-factor-backup-code'] );
 	}
 
 	/**

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -55,13 +55,16 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	public static function admin_notices() {
 		// Only show this notice if we are out of backup codes.
 		$user_id = get_current_user_id();
-		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
-		if ( ! empty( $backup_codes ) ) {
+		$user = get_user_by( 'id', $user_id );
+		$backup_codes = get_user_meta( $user->ID, self::BACKUP_CODES_META_KEY, true );
+
+		// Exit if we are not out of codes
+		if( 0 < self::codes_remaining_for_user( $user ) ) {
 			return;
 		}
 
 		// Only show when the provider is enabled.
-		if ( ! in_array( __CLASS__, Two_Factor_Core::get_enabled_providers_for_user( $user_id ) ) ) {
+		if ( ! in_array( __CLASS__, Two_Factor_Core::get_enabled_providers_for_user( $user->ID ) ) ) {
 			return;
 		}
 		?>

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -124,6 +124,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 			jQuery( document ).ready( function( $ ) {
 				$( '.button-two-factor-backup-codes-generate' ).click( function() {
 					$.ajax( {
+						method: 'POST',
 						url: ajaxurl,
 						data: {
 							action: 'two_factor_backup_codes_generate',
@@ -193,7 +194,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 * @since 0.1-dev
 	 */
 	public function ajax_generate_json() {
-		$user = get_user_by( 'id', sanitize_text_field( $_GET['user_id'] ) );
+		$user = get_user_by( 'id', sanitize_text_field( $_POST['user_id'] ) );
 		check_ajax_referer( 'two-factor-backup-codes-generate-json-' . $user->ID, 'nonce' );
 
 		// Setup the return data.

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -30,8 +30,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 			return;
 		}
 		// Only show this if the provider is enabled
-		$enabled_providers = get_user_meta( $user_id, Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY, true );
-		if( ! in_array( __CLASS__, $enabled_providers ) ) {
+		if( $this->is_enabled() ) {
 			return;
 		}
 
@@ -40,6 +39,15 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 			<p><?php echo sprintf( __( 'Two-Factor: You are out of backup codes and need to <a href="%1$s#two-factor-backup-codes" >regenerate</a>!', 'two-factor' ), esc_url( get_edit_user_link( $user_id ) ) ); ?></p>
 		</div>
 		<?php
+	}
+
+	function is_enabled() {
+		// Only show this if the provider is enabled
+		$enabled_providers = get_user_meta( $user_id, Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY, true );
+		if( in_array( __CLASS__, $enabled_providers ) ) {
+			return true;
+		}
+		return false;
 	}
 
 	function get_label() {
@@ -86,7 +94,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 							$('.two-factor-backup-codes-count').html( data.length );
 						},
 						error: function(errorThrown){
-							alert('error');
+							alert('error'); // @todo: remove for production
 							console.log(errorThrown);
 						}
 					});

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -59,7 +59,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 
 		// Exit if we are not out of codes.
 		if ( 0 < self::codes_remaining_for_user( $user ) ) {
-		//	return;
+			return;
 		}
 
 		// Only show when the provider is enabled.

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -48,21 +48,20 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	}
 
 	/**
-	 * Displays an admin notice when backup codes have ran out.
+	 * Displays an admin notice when backup codes have run out.
 	 *
 	 * @since 0.1-dev
 	 */
 	public static function admin_notices() {
-		// Only show this notice if we are out of backup codes.
 		$user = wp_get_current_user();
 
-		// Exit if we are not out of codes.
-		if ( 0 < self::codes_remaining_for_user( $user ) ) {
+		// Exit if the provider is not enabled.
+		if ( ! in_array( __CLASS__, Two_Factor_Core::get_enabled_providers_for_user( $user->ID ) ) ) {
 			return;
 		}
 
-		// Only show when the provider is enabled.
-		if ( ! in_array( __CLASS__, Two_Factor_Core::get_enabled_providers_for_user( $user->ID ) ) ) {
+		// Exit if we are not out of codes.
+		if ( 0 < self::codes_remaining_for_user( $user ) ) {
 			return;
 		}
 		?>

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -66,7 +66,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		}
 		?>
 		<div class="error">
-			<p><?php echo sprintf( __( 'Two-Factor: You are out of backup codes and need to <a href="%1$s#two-factor-backup-codes" >regenerate</a>!', 'two-factor' ), esc_url( get_edit_user_link( $user_id ) ) ); ?></p>
+			<p><?php echo esc_html( sprintf( __( 'Two-Factor: You are out of backup codes and need to <a href="%1$s#two-factor-backup-codes" >regenerate</a>!', 'two-factor' ), esc_url( get_edit_user_link( $user_id ) ) ) ); ?></p>
 		</div>
 		<?php
 	}
@@ -121,8 +121,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 			<button type="button" class="button button-two-factor-backup-codes-generate button-secondary hide-if-no-js">
 				<?php esc_html_e( 'Generate Verification Codes', 'two-factor' ); ?>
 			</button>
-			<?php echo sprintf( __( '<kbd><span class="two-factor-backup-codes-count">%1$s</span> unused codes remaining.</kbd>', 'two-factor' ), count( $backup_codes ) ); ?>
-
+			<?php echo esc_html( sprintf( __( '<span class="two-factor-backup-codes-count">%1$s</span> unused codes remaining.', 'two-factor' ), count( $backup_codes ) ) ); ?>
 		</p>
 		<div class="two-factor-backup-codes-wrapper" style="display:none;">
 			<ol class="two-factor-backup-codes-unused-codes"></ol>
@@ -162,12 +161,14 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 * Generates backup codes & updates the user meta.
 	 *
 	 * @since 0.1-dev
+	 *
+	 * @param int $user_id The logged-in user ID.
 	 */
 	public function generate_codes( $user_id ) {
 		$codes = array();
 		$codes_hashed = array();
 
-		for( $i = 0; $i < self::NUMBER_OF_CODES; $i++ ) {
+		for ( $i = 0; $i < self::NUMBER_OF_CODES; $i++ ) {
 			$code = $this->get_code();
 			$codes_hashed[] = wp_hash_password( $code );
 			$codes[] = $code;
@@ -190,10 +191,10 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 
 		$user_id = get_current_user_id();
 		$codes = $this->generate_codes( $user_id );
-		$json_codes = json_encode( $codes );
+		$json_codes = wp_json_encode( $codes );
 
 		echo $json_codes;
-		die(0);
+		die( 0 );
 	}
 
 	/**
@@ -243,7 +244,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	public function validate_code( $user_id, $code ) {
 		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
 
-		foreach( $backup_codes as $code_index => $backup_code ) {
+		foreach ( $backup_codes as $code_index => $backup_code ) {
 			if ( wp_check_password( $code, $backup_code, $user_id ) ) {
 				$this->delete_code( $user_id, $code_index );
 				return true;
@@ -259,7 +260,6 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 *
 	 * @param int $user_id    The logged-in user ID.
 	 * @param int $code_index The array index of the backup code.
-	 * @return boolean
 	 */
 	public function delete_code( $user_id, $code_index ) {
 		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -61,7 +61,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		}
 
 		// Only show when the provider is enabled.
-		if ( ! self::is_enabled( $user_id ) ) {
+		if ( ! in_array( __CLASS__, Two_Factor_Core::get_enabled_providers_for_user( $user_id ) ) ) {
 			return;
 		}
 		?>
@@ -72,20 +72,6 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 			</p>
 		</div>
 		<?php
-	}
-
-	/**
-	 * Verify the provider is enabled.
-	 *
-	 * @since 0.1-dev
-	 *
-	 * @param int $user_id The logged-in user ID.
-	 */
-	public static function is_enabled( $user_id ) {
-		if ( in_array( __CLASS__, Two_Factor_Core::get_enabled_providers_for_user( $user_id ) ) ) {
-			return true;
-		}
-		return false;
 	}
 
 	/**
@@ -172,7 +158,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 * @param array $args Optional arguments for assinging new codes.
 	 */
 	public function generate_codes( $user_id, $args = '' ) {
-		$user = get_user_by('id', $user_id);
+		$user = get_user_by( 'id', $user_id );
 		$codes = array();
 		$codes_hashed = array();
 

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -98,7 +98,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	}
 
 	/**
-	 * Whether this Two Factor provider is configured and available for the user specified.
+	 * Whether this Two Factor provider is configured and codes are available for the user specified.
 	 *
 	 * @since 0.1-dev
 	 *
@@ -106,7 +106,11 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 * @return boolean
 	 */
 	public function is_available_for_user( $user ) {
-		return true;
+		$backup_codes = get_user_meta( $user->ID, self::BACKUP_CODES_META_KEY, true );
+		if ( ! empty( $backup_codes ) ) {
+			return true;
+		}
+		return false;
 	}
 
 	/**

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -121,7 +121,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 				<?php esc_html_e( 'Generate Verification Codes' ); ?>
 			</button>
 			<span class="two-factor-backup-codes-count"><?php echo self::codes_remaining_for_user( $user ); ?></span>
-			<span><?php _e( ' unsused codes remaining.' ); ?><span>
+			<span><?php echo _n( ' unused code remaining.', ' unused codes remaining.', self::codes_remaining_for_user( $user ) ) ?><span>
 		</p>
 		<div class="two-factor-backup-codes-wrapper" style="display:none;">
 			<ol class="two-factor-backup-codes-unused-codes"></ol>
@@ -201,7 +201,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	public function ajax_generate_json() {
 		$user = get_user_by( 'id', sanitize_text_field( $_REQUEST['user_id'] ) );
 		check_ajax_referer( 'two-factor-backup-codes-generate-json-' . $user->ID, 'nonce' );
-		$codes = $this->generate_codes( $user );
+		$codes = $this->generate_codes( $user, array('number' => '1') );
 		wp_send_json_success( $codes );
 	}
 

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -18,23 +18,11 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 
 	protected function __construct() {
 		//add_action( 'two-factor-user-options-' . __CLASS__, array( $this, 'user_options' ) );
-		return parent::__construct();
-	}
-
-	public static function add_hooks() {
-		$user_id = get_current_user_id();
-		//$primary_provider = get_user_meta( $user_id, Two_Factor_Core::PROVIDER_USER_META_KEY, true );
-		$enabled_providers = Two_Factor_Core::get_enabled_providers_for_user( $user_id );
-
-		// Only do these things when Backup Codes are enabled,
-		if( ! in_array( 'Two_Factor_Backup_Codes', $enabled_providers ) ) {
-			return;
-		}
-
 		add_action( 'admin_notices', array( __CLASS__, 'admin_notices' ) );
 		add_action( 'user_two_factor_options', array( __CLASS__, 'user_two_factor_options' ) );
-
 		add_action( 'wp_ajax_two_factor_backup_codes_generate', array( __CLASS__, 'ajax_generate_json' ) );
+
+		return parent::__construct();
 	}
 
 	public static function admin_notices() {
@@ -56,21 +44,26 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		return _x( 'Backup Verification Codes (Single Use)', 'Provider Label', 'two-factor' );
 	}
 
-
 	function is_available_for_user( $user ) {
 		return true;
 	}
 
 	function user_options( $user ) {
+		$user_id = get_current_user_id();
+		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
+		$ajax_nonce = wp_create_nonce( 'two-factor-backup-codes-generate-json' );
 		?>
-		<button type="button" class="button button-two-factor-backup-codes-generate button-secondary hide-if-no-js">Generate Verification Codes</button>
+			<button type="button" class="button button-two-factor-backup-codes-generate button-secondary hide-if-no-js">Generate Verification Codes</button>
+			<p class="description"><span class="two-factor-backup-codes-count"><?php echo count( $backup_codes ); ?></span> unused codes remaining.</p>
+			<div class="two-factor-backup-codes-wrapper" style="display:none;">
+				<ol class="two-factor-backup-codes-unused-codes"></ol>
+				<p class="description">Write 'em down y'all!</p>
+			</div>
 		<?php
 	}
 
 	public static function user_two_factor_options() {
 		$user_id = get_current_user_id();
-
-		// Only show this notice if we are out of backup codes
 		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
 		$ajax_nonce = wp_create_nonce( 'two-factor-backup-codes-generate-json' );
 		?>
@@ -231,4 +224,3 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	}
 
 }
-Two_Factor_Backup_Codes::add_hooks();

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -214,5 +214,13 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		return $this->validate_code( $user->ID, $_REQUEST['two-factor-backup-code'] );
 	}
 
+	function is_available_for_user( $user ) {
+		return true;
+	}
+
+	function user_options( $user ) {
+
+	}
+
 }
 Two_Factor_Backup_Codes::add_hooks();

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -185,9 +185,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 
 		// Append or replace (default)
 		if( isset( $args['method'] ) && 'append' == $args['method'] ) {
-			//$num_existing_codes = self::codes_remaining_for_user( $user );
 			$codes_hashed = get_user_meta( $user->ID, self::BACKUP_CODES_META_KEY, true );
-			//$num_codes += $num_existing_codes;
 		}
 
 		for ( $i = 0; $i < $num_codes; $i++ ) {

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -61,7 +61,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		}
 
 		// Only show when the provider is enabled.
-		if ( false === self::is_enabled( $user_id ) ) {
+		if ( ! self::is_enabled( $user_id ) ) {
 			return;
 		}
 		?>

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -16,12 +16,18 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		return $instance;
 	}
 
+	protected function __construct() {
+		//add_action( 'two-factor-user-options-' . __CLASS__, array( $this, 'user_options' ) );
+		return parent::__construct();
+	}
+
 	public static function add_hooks() {
 		$user_id = get_current_user_id();
-		$primary_provider = get_user_meta( $user_id, Two_Factor_Core::PROVIDER_USER_META_KEY, true );
+		//$primary_provider = get_user_meta( $user_id, Two_Factor_Core::PROVIDER_USER_META_KEY, true );
+		$enabled_providers = Two_Factor_Core::get_enabled_providers_for_user( $user_id );
 
-		// Only do these things when Backup Codes are selected as the primary provider.
-		if( 'Two_Factor_Backup_Codes' != $primary_provider ) {
+		// Only do these things when Backup Codes are enabled,
+		if( ! in_array( 'Two_Factor_Backup_Codes', $enabled_providers ) ) {
 			return;
 		}
 
@@ -219,7 +225,9 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	}
 
 	function user_options( $user ) {
-
+		?>
+		<button type="button" class="button button-two-factor-backup-codes-generate button-secondary hide-if-no-js">Generate Verification Codes</button>
+		<?php
 	}
 
 }

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -69,7 +69,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		<div class="error">
 			<p>
 				<span><?php esc_html_e( 'Two-Factor: You are out of backup codes and need to ' ); ?><span>
-				<a href="<?php echo esc_url( get_edit_user_link( $user->ID ) . '#two-factor-backup-codes' ); ?>">regenerate!</a>
+				<a href="<?php echo esc_url( get_edit_user_link( $user->ID ) . '#two-factor-backup-codes' ); ?>"><?php esc_html_e( 'regenerate!' ); ?></a>
 			</p>
 		</div>
 		<?php

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -61,7 +61,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		}
 
 		// Only show when the provider is enabled.
-		if ( false === Two_Factor_Backup_Codes::get_instance()->is_enabled( $user_id ) ) {
+		if ( false === self::is_enabled( $user_id ) ) {
 			return;
 		}
 		?>
@@ -81,9 +81,8 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 *
 	 * @param int $user_id The logged-in user ID.
 	 */
-	public function is_enabled( $user_id ) {
-		$enabled_providers = (array) get_user_meta( $user_id, Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY, true );
-		if ( in_array( __CLASS__, $enabled_providers ) ) {
+	public static function is_enabled( $user_id ) {
+		if ( in_array( __CLASS__, Two_Factor_Core::get_enabled_providers_for_user( $user_id ) ) ) {
 			return true;
 		}
 		return false;

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -66,7 +66,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		}
 		?>
 		<div class="error">
-			<p><?php echo wp_kses( sprintf( __( 'Two-Factor: You are out of backup codes and need to <a href="%1$s#two-factor-backup-codes" >regenerate</a>!', 'two-factor' ), esc_url( get_edit_user_link( $user_id ) ) ), array( 'a' => array( 'href' => array() ) ) ); ?></p>
+			<p><?php echo wp_kses( sprintf( __( 'Two-Factor: You are out of backup codes and need to <a href="%1$s#two-factor-backup-codes" >regenerate</a>!' ), esc_url( get_edit_user_link( $user_id ) ) ), array( 'a' => array( 'href' => array() ) ) ); ?></p>
 		</div>
 		<?php
 	}
@@ -92,7 +92,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 * @since 0.1-dev
 	 */
 	public function get_label() {
-		return _x( 'Backup Verification Codes (Single Use)', 'Provider Label', 'two-factor' );
+		return _x( 'Backup Verification Codes (Single Use)', 'Provider Label' );
 	}
 
 	/**
@@ -121,7 +121,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		?>
 		<p id="two-factor-backup-codes">
 			<button type="button" class="button button-two-factor-backup-codes-generate button-secondary hide-if-no-js">
-				<?php esc_html_e( 'Generate Verification Codes', 'two-factor' ); ?>
+				<?php esc_html_e( 'Generate Verification Codes' ); ?>
 			</button>
 			<?php echo wp_kses( sprintf( _n( '%s unused code remaining.', '%s unused codes remaining.', count( $backup_codes ) ), '<span class="two-factor-backup-codes-count">' . count( $backup_codes ) . '</span>' ), array( 'span' => array( 'class' => array() ) ) ); ?>
 		</p>
@@ -209,13 +209,13 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	public function authentication_page( $user ) {
 		require_once( ABSPATH .  '/wp-admin/includes/template.php' );
 		?>
-		<p><?php esc_html_e( 'Enter a backup verification code.', 'two-factor' ); ?></p><br/>
+		<p><?php esc_html_e( 'Enter a backup verification code.' ); ?></p><br/>
 		<p>
-			<label for="authcode"><?php esc_html_e( 'Verification Code:', 'two-factor' ); ?></label>
+			<label for="authcode"><?php esc_html_e( 'Verification Code:' ); ?></label>
 			<input type="tel" name="two-factor-backup-code" id="authcode" class="input" value="" size="20" pattern="[0-9]*" />
 		</p>
 		<?php
-		submit_button( __( 'Submit', 'two-factor' ) );
+		submit_button( __( 'Submit' ) );
 	}
 
 	/**

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -19,7 +19,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	protected function __construct() {
 		add_action( 'two-factor-user-options-' . __CLASS__, array( $this, 'user_options' ) );
 		add_action( 'admin_notices', array( $this, 'admin_notices' ) );
-		add_action( 'user_two_factor_options', array( $this, 'user_two_factor_options' ) );
+		add_action( 'after_two_factor_user_options', array( $this, 'user_two_factor_options' ) );
 		add_action( 'wp_ajax_two_factor_backup_codes_generate', array( $this, 'ajax_generate_json' ) );
 
 		return parent::__construct();
@@ -69,7 +69,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 						<p>Two-Factor Backup Verification Codes are single use codes that can be used to login.</p>
 						<p></p>
 						<button type="button" class="button button-two-factor-backup-codes-generate button-secondary hide-if-no-js">Generate Verification Codes</button>
-						<p class="description"><span class="two-factor-backup-codes-count"><?php echo count( $backup_codes ); ?></span> unused codes remaining.</p>
+						<!--<p class="description"><span class="two-factor-backup-codes-count"><?php echo count( $backup_codes ); ?></span> unused codes remaining.</p>-->
 						<div class="two-factor-backup-codes-wrapper" style="display:none;">
 							<ol class="two-factor-backup-codes-unused-codes"></ol>
 							<p class="description">Write 'em down y'all!</p>

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -27,7 +27,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		$user_id = get_current_user_id();
 		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
 		if( ! empty( $backup_codes ) ) {
-		//	return;
+			return;
 		}
 		// Only show this if the provider is enabled
 		$enabled_providers = get_user_meta( $user_id, Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY, true );

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -103,7 +103,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	function ajax_generate_json() {
 		check_ajax_referer( 'two-factor-backup-codes-generate-json', 'nonce' );
 		$user_id = get_current_user_id();
-		$codes = self::get_instance()->generate_codes( $user_id );
+		$codes = $this->generate_codes( $user_id );
 		$json_codes = json_encode( $codes );
 		echo $json_codes;
 		die(0);
@@ -114,7 +114,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		?>
 		<p><?php esc_html_e( 'Enter a backup verification code.', 'two-factor' ); ?></p><br/>
 		<p>
-			<label for="authcode"><?php esc_html_e( 'Verification Code:' ); ?></label>
+			<label for="authcode"><?php esc_html_e( 'Verification Code:', 'two-factor' ); ?></label>
 			<input type="tel" name="two-factor-backup-code" id="authcode" class="input" value="" size="20" pattern="[0-9]*" />
 		</p>
 		<?php

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -66,7 +66,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		}
 		?>
 		<div class="error">
-			<p><?php echo esc_html( sprintf( __( 'Two-Factor: You are out of backup codes and need to <a href="%1$s#two-factor-backup-codes" >regenerate</a>!', 'two-factor' ), esc_url( get_edit_user_link( $user_id ) ) ) ); ?></p>
+			<p><?php echo wp_kses( sprintf( __( 'Two-Factor: You are out of backup codes and need to <a href="%1$s#two-factor-backup-codes" >regenerate</a>!', 'two-factor' ), esc_url( get_edit_user_link( $user_id ) ) ), array(  'a' => array( 'href' => array() ) ) ); ?></p>
 		</div>
 		<?php
 	}
@@ -123,7 +123,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 			<button type="button" class="button button-two-factor-backup-codes-generate button-secondary hide-if-no-js">
 				<?php esc_html_e( 'Generate Verification Codes', 'two-factor' ); ?>
 			</button>
-			<?php echo esc_html( sprintf( __( '<span class="two-factor-backup-codes-count">%1$s</span> unused codes remaining.', 'two-factor' ), count( $backup_codes ) ) ); ?>
+			<?php echo wp_kses( sprintf( __( '<span class="two-factor-backup-codes-count">%s</span> unused codes remaining.', 'two-factor' ), count( $backup_codes ) ), array(  'span' => array( 'class' => array() ) ) ); ?>
 		</p>
 		<div class="two-factor-backup-codes-wrapper" style="display:none;">
 			<ol class="two-factor-backup-codes-unused-codes"></ol>

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -60,7 +60,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 			return;
 		}
 
-		// Exit if we are not out of codes.
+		// Return if we are not out of codes.
 		if ( 0 < self::codes_remaining_for_user( $user ) ) {
 			return;
 		}

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -1,10 +1,30 @@
 <?php
-
+/**
+ * Class for creating a backup codes provider.
+ *
+ * @since 0.1-dev
+ *
+ * @package Two_Factor
+ */
 class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 
+	/**
+	 * The user meta backup codes key.
+	 * @type string
+	 */
 	const BACKUP_CODES_META_KEY = '_two_factor_backup_codes';
+
+	/**
+	 * The number backup codes.
+	 * @type int
+	 */
 	const NUMBER_OF_CODES = 10;
 
+	/**
+	 * Ensures only one instance of this class exists in memory at any one time.
+	 *
+	 * @since 0.1-dev
+	 */
 	static function get_instance() {
 		static $instance;
 		$class = __CLASS__;
@@ -14,6 +34,11 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		return $instance;
 	}
 
+	/**
+	 * Class constructor.
+	 *
+	 * @since 0.1-dev
+	 */
 	protected function __construct() {
 		add_action( 'two-factor-user-options-' . __CLASS__, array( $this, 'user_options' ) );
 		add_action( 'admin_notices', array( $this, 'admin_notices' ) );
@@ -22,18 +47,23 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		return parent::__construct();
 	}
 
+	/**
+	 * Displays an admin notice when backup codes have ran out.
+	 *
+	 * @since 0.1-dev
+	 */
 	public static function admin_notices() {
-		// Only show this notice if we are out of backup codes
+		// Only show this notice if we are out of backup codes.
 		$user_id = get_current_user_id();
 		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
-		if( ! empty( $backup_codes ) ) {
-			return;
-		}
-		// Only show this if the provider is enabled
-		if( $this->is_enabled() ) {
+		if ( ! empty( $backup_codes ) ) {
 			return;
 		}
 
+		// Only show this if the provider is enabled.
+		if ( $this->is_enabled() ) {
+			return;
+		}
 		?>
 		<div class="error">
 			<p><?php echo sprintf( __( 'Two-Factor: You are out of backup codes and need to <a href="%1$s#two-factor-backup-codes" >regenerate</a>!', 'two-factor' ), esc_url( get_edit_user_link( $user_id ) ) ); ?></p>
@@ -41,24 +71,48 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		<?php
 	}
 
-	function is_enabled() {
-		// Only show this if the provider is enabled
+	/**
+	 * Verify the provider is enabled.
+	 *
+	 * @since 0.1-dev
+	 */
+	public function is_enabled() {
 		$enabled_providers = get_user_meta( $user_id, Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY, true );
-		if( in_array( __CLASS__, $enabled_providers ) ) {
+		if ( in_array( __CLASS__, $enabled_providers ) ) {
 			return true;
 		}
 		return false;
 	}
 
-	function get_label() {
+	/**
+	 * Returns the name of the provider.
+	 *
+	 * @since 0.1-dev
+	 */
+	public function get_label() {
 		return _x( 'Backup Verification Codes (Single Use)', 'Provider Label', 'two-factor' );
 	}
 
-	function is_available_for_user( $user ) {
+	/**
+	 * Whether this Two Factor provider is configured and available for the user specified.
+	 *
+	 * @since 0.1-dev
+	 *
+	 * @param WP_User $user WP_User object of the logged-in user.
+	 * @return boolean
+	 */
+	public function is_available_for_user( $user ) {
 		return true;
 	}
 
-	function user_options( $user ) {
+	/**
+	 * Inserts markup at the end of the user profile field for this provider.
+	 *
+	 * @since 0.1-dev
+	 *
+	 * @param WP_User $user WP_User object of the logged-in user.
+	 */
+	public function user_options( $user ) {
 		$user_id = get_current_user_id();
 		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
 		$ajax_nonce = wp_create_nonce( 'two-factor-backup-codes-generate-json' );
@@ -90,7 +144,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 							$.each( data, function( key, val ) {
 								$('.two-factor-backup-codes-unused-codes').append('<li>'+val+'</li>');
 							});
-							// Update counter
+							// Update counter.
 							$('.two-factor-backup-codes-count').html( data.length );
 						},
 						error: function(errorThrown){
@@ -104,29 +158,52 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		<?php
 	}
 
-	function generate_codes( $user_id ) {
+	/**
+	 * Generates backup codes & updates the user meta.
+	 *
+	 * @since 0.1-dev
+	 */
+	public function generate_codes( $user_id ) {
 		$codes = array();
 		$codes_hashed = array();
+
 		for( $i = 0; $i < self::NUMBER_OF_CODES; $i++ ) {
 			$code = $this->get_code();
 			$codes_hashed[] = wp_hash_password( $code );
 			$codes[] = $code;
 			unset( $code );
 		}
+
 		update_user_meta( $user_id, self::BACKUP_CODES_META_KEY, $codes_hashed );
-		return $codes; //unhashed
+
+		// Unhashed.
+		return $codes;
 	}
 
-	function ajax_generate_json() {
+	/**
+	 * Generates a JSON object of backup codes.
+	 *
+	 * @since 0.1-dev
+	 */
+	public function ajax_generate_json() {
 		check_ajax_referer( 'two-factor-backup-codes-generate-json', 'nonce' );
+
 		$user_id = get_current_user_id();
 		$codes = $this->generate_codes( $user_id );
 		$json_codes = json_encode( $codes );
+
 		echo $json_codes;
 		die(0);
 	}
 
-	function authentication_page( $user ) {
+	/**
+	 * Prints the form that prompts the user to authenticate.
+	 *
+	 * @since 0.1-dev
+	 *
+	 * @param WP_User $user WP_User object of the logged-in user.
+	 */
+	public function authentication_page( $user ) {
 		require_once( ABSPATH .  '/wp-admin/includes/template.php' );
 		?>
 		<p><?php esc_html_e( 'Enter a backup verification code.', 'two-factor' ); ?></p><br/>
@@ -138,16 +215,36 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		submit_button( __( 'Submit', 'two-factor' ) );
 	}
 
-	function validate_authentication( $user ) {
+	/**
+	 * Validates the users input token.
+	 *
+	 * In this class we just return true.
+	 *
+	 * @since 0.1-dev
+	 *
+	 * @param WP_User $user WP_User object of the logged-in user.
+	 * @return boolean
+	 */
+	public function validate_authentication( $user ) {
 		return $this->validate_code( $user->ID, $_REQUEST['two-factor-backup-code'] );
 	}
 
-	function validate_code( $user_id, $code ) {
+	/**
+	 * Validates a backup code.
+	 *
+	 * Backup Codes are single use and are deleted upon a successful validation.
+	 *
+	 * @since 0.1-dev
+	 *
+	 * @param int $user_id The logged-in user ID.
+	 * @param int $code    The backup code.
+	 * @return boolean
+	 */
+	public function validate_code( $user_id, $code ) {
 		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
 
 		foreach( $backup_codes as $code_index => $backup_code ) {
-			if( wp_check_password( $code, $backup_code, $user_id ) ) {
-				// Backup Codes are single use and are deleted upon a successful validation
+			if ( wp_check_password( $code, $backup_code, $user_id ) ) {
 				$this->delete_code( $user_id, $code_index );
 				return true;
 			}
@@ -155,14 +252,23 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		return false;
 	}
 
-	function delete_code( $user_id, $code_index ) {
+	/**
+	 * Deletes a backup code.
+	 *
+	 * @since 0.1-dev
+	 *
+	 * @param int $user_id    The logged-in user ID.
+	 * @param int $code_index The array index of the backup code.
+	 * @return boolean
+	 */
+	public function delete_code( $user_id, $code_index ) {
 		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
 
-		// delete the current code from the list since it's been used.
+		// Delete the current code from the list since it's been used.
 		unset( $backup_codes[ $code_index ] );
 		$backup_codes = array_values( $backup_codes );
 
-		// Update the backup code master list
+		// Update the backup code master list.
 		update_user_meta( $user_id, self::BACKUP_CODES_META_KEY, $backup_codes );
 	}
 }

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -59,11 +59,11 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 
 		// Exit if we are not out of codes
 		/*
-		if( ! self::is_available_for_user( $user ) ) {
+		if ( ! self::is_available_for_user( $user ) ) {
 			return;
 		}
 		*/
-		if( 0 < self::codes_remaining_for_user( $user ) ) {
+		if ( 0 < self::codes_remaining_for_user( $user ) ) {
 			return;
 		}
 
@@ -100,7 +100,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 */
 	public function is_available_for_user( $user ) {
 		// Does this user have available codes?
-		if( 0 < self::codes_remaining_for_user( $user ) ) {
+		if ( 0 < self::codes_remaining_for_user( $user ) ) {
 			return true;
 		}
 		return false;
@@ -169,14 +169,14 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		$codes_hashed = array();
 
 		// Check for arguments
-		if( isset( $args['number'] ) ) {
+		if ( isset( $args['number'] ) ) {
 			$num_codes = (int) $args['number'];
 		} else {
 			$num_codes = self::NUMBER_OF_CODES;
 		}
 
 		// Append or replace (default)
-		if( isset( $args['method'] ) && 'append' == $args['method'] ) {
+		if ( isset( $args['method'] ) && 'append' == $args['method'] ) {
 			$codes_hashed = get_user_meta( $user->ID, self::BACKUP_CODES_META_KEY, true );
 		}
 

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -203,8 +203,8 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	/**
 	 * Returns the number of unused codes for the specified user
 	 *
-	 * @param  WP_User $user WP_User object of the logged-in user.
-	 * @return int     $int  The number of unused codes remaining
+	 * @param WP_User $user WP_User object of the logged-in user.
+	 * @return int $int  The number of unused codes remaining
 	 */
 	public static function codes_remaining_for_user( $user ) {
 		$backup_codes = get_user_meta( $user->ID, self::BACKUP_CODES_META_KEY, true );
@@ -254,8 +254,8 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 *
 	 * @since 0.1-dev
 	 *
-	 * @param  WP_User $user WP_User object of the logged-in user.
-	 * @param  int     $code The backup code.
+	 * @param WP_User $user WP_User object of the logged-in user.
+	 * @param int     $code The backup code.
 	 * @return boolean
 	 */
 	public function validate_code( $user, $code ) {

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -163,15 +163,15 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		$codes = array();
 		$codes_hashed = array();
 
-		// Check for arguments
+		// Check for arguments.
 		if ( isset( $args['number'] ) ) {
 			$num_codes = (int) $args['number'];
 		} else {
 			$num_codes = self::NUMBER_OF_CODES;
 		}
 
-		// Append or replace (default)
-		if ( isset( $args['method'] ) && 'append' == $args['method'] ) {
+		// Append or replace (default).
+		if ( isset( $args['method'] ) && 'append' === $args['method'] ) {
 			$codes_hashed = get_user_meta( $user->ID, self::BACKUP_CODES_META_KEY, true );
 		}
 
@@ -276,7 +276,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 * @since 0.1-dev
 	 *
 	 * @param WP_User $user WP_User object of the logged-in user.
-	 * @param int $code_index The array index of the backup code.
+	 * @param string  $code_hashed The hashed the backup code.
 	 */
 	public function delete_code( $user, $code_hashed ) {
 		$backup_codes = get_user_meta( $user->ID, self::BACKUP_CODES_META_KEY, true );

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -130,31 +130,32 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 			<p class="description"><?php esc_html_e( "Write 'em down y'all!" ); ?></p>
 		</div>
 		<script type="text/javascript">
-			jQuery(document).ready(function($) {
-				$('.button-two-factor-backup-codes-generate').click( function() {
-					jQuery.ajax({
+			// @todo: move this into a JS file & internationalize the count strings
+			jQuery( document ).ready( function( $ ) {
+				$( '.button-two-factor-backup-codes-generate' ).click( function() {
+					jQuery.ajax( {
 						url: ajaxurl,
-						data:{
+						data: {
 							action: 'two_factor_backup_codes_generate',
 							nonce: '<?php echo esc_js( $ajax_nonce ); ?>'
 						},
 						dataType: 'JSON',
-						success:function(data){
-							$('.two-factor-backup-codes-wrapper').show();
-							$('.two-factor-backup-codes-unused-codes').html('');
+						success: function( data ) {
+							$( '.two-factor-backup-codes-wrapper' ).show();
+							$( '.two-factor-backup-codes-unused-codes' ).html( '' );
 							$.each( data, function( key, val ) {
-								$('.two-factor-backup-codes-unused-codes').append('<li>'+val+'</li>');
-							});
+								$( '.two-factor-backup-codes-unused-codes' ).append( '<li>' + val + '</li>' );
+							} );
 							// Update counter.
-							$('.two-factor-backup-codes-count').html( data.length );
+							$( '.two-factor-backup-codes-count' ).html( data.length );
 						},
-						error: function(errorThrown){
-							alert('error'); // @todo: remove for production
-							console.log(errorThrown);
+						error: function( errorThrown ) {
+							alert( 'error' ); // @todo: remove for production
+							console.log( errorThrown );
 						}
-					});
-				});
-			});
+					} );
+				} );
+			} );
 		</script>
 		<?php
 	}
@@ -193,10 +194,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 
 		$user_id = get_current_user_id();
 		$codes = $this->generate_codes( $user_id );
-		$json_codes = wp_json_encode( $codes );
-
-		echo $json_codes;
-		die( 0 );
+		wp_send_json( $codes );
 	}
 
 	/**

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -113,7 +113,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 * @param WP_User $user WP_User object of the logged-in user.
 	 */
 	public function user_options( $user ) {
-		$user_id = get_current_user_id();
+		$user_id = $user->ID;
 		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
 		$ajax_nonce = wp_create_nonce( 'two-factor-backup-codes-generate-json' );
 		?>

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -17,7 +17,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	}
 
 	protected function __construct() {
-		//add_action( 'two-factor-user-options-' . __CLASS__, array( $this, 'user_options' ) );
+		add_action( 'two-factor-user-options-' . __CLASS__, array( $this, 'user_options' ) );
 		add_action( 'admin_notices', array( $this, 'admin_notices' ) );
 		add_action( 'user_two_factor_options', array( $this, 'user_two_factor_options' ) );
 		add_action( 'wp_ajax_two_factor_backup_codes_generate', array( $this, 'ajax_generate_json' ) );
@@ -52,12 +52,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
 		$ajax_nonce = wp_create_nonce( 'two-factor-backup-codes-generate-json' );
 		?>
-			<button type="button" class="button button-two-factor-backup-codes-generate button-secondary hide-if-no-js">Generate Verification Codes</button>
-			<p class="description"><span class="two-factor-backup-codes-count"><?php echo count( $backup_codes ); ?></span> unused codes remaining.</p>
-			<div class="two-factor-backup-codes-wrapper" style="display:none;">
-				<ol class="two-factor-backup-codes-unused-codes"></ol>
-				<p class="description">Write 'em down y'all!</p>
-			</div>
+			<kbd><span class="two-factor-backup-codes-count"><?php echo count( $backup_codes ); ?></span> unused codes remaining.</kbd>
 		<?php
 	}
 

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -60,8 +60,8 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 			return;
 		}
 
-		// Only show this if the provider is enabled.
-		if ( $this->is_enabled() ) {
+		// Only show when the provider is enabled.
+		if ( false === Two_Factor_Backup_Codes::get_instance()->is_enabled( $user_id ) ) {
 			return;
 		}
 		?>
@@ -75,9 +75,11 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 * Verify the provider is enabled.
 	 *
 	 * @since 0.1-dev
+	 *
+	 * @param int $user_id The logged-in user ID.
 	 */
-	public function is_enabled() {
-		$enabled_providers = get_user_meta( $user_id, Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY, true );
+	public function is_enabled( $user_id ) {
+		$enabled_providers = (array) get_user_meta( $user_id, Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY, true );
 		if ( in_array( __CLASS__, $enabled_providers ) ) {
 			return true;
 		}

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -27,8 +27,14 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		$user_id = get_current_user_id();
 		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
 		if( ! empty( $backup_codes ) ) {
+		//	return;
+		}
+		// Only show this if the provider is enabled
+		$enabled_providers = get_user_meta( $user_id, Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY, true );
+		if( ! in_array( 'Two_Factor_Backup_Codes', $enabled_providers ) ) {
 			return;
 		}
+
 		?>
 		<div class="error">
 			<p><?php echo sprintf( __( 'Two-Factor: You are out of backup codes and need to <a href="%1$s#two-factor-backup-codes" >regenerate</a>!', 'two-factor' ), esc_url( get_edit_user_link( $user_id ) ) ); ?></p>

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -66,7 +66,10 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		}
 		?>
 		<div class="error">
-			<p><?php echo wp_kses( sprintf( __( 'Two-Factor: You are out of backup codes and need to <a href="%1$s#two-factor-backup-codes" >regenerate</a>!' ), esc_url( get_edit_user_link( $user_id ) ) ), array( 'a' => array( 'href' => array() ) ) ); ?></p>
+			<p>
+				<span><?php _e( 'Two-Factor: You are out of backup codes and need to '); ?><span>
+				<a href="<?php echo get_edit_user_link( $user_id ); ?>#two-factor-backup-codes">regenerate!</a>
+			</p>
 		</div>
 		<?php
 	}
@@ -123,7 +126,8 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 			<button type="button" class="button button-two-factor-backup-codes-generate button-secondary hide-if-no-js">
 				<?php esc_html_e( 'Generate Verification Codes' ); ?>
 			</button>
-			<?php echo wp_kses( sprintf( _n( '%s unused code remaining.', '%s unused codes remaining.', count( $backup_codes ) ), '<span class="two-factor-backup-codes-count">' . count( $backup_codes ) . '</span>' ), array( 'span' => array( 'class' => array() ) ) ); ?>
+			<span class="two-factor-backup-codes-count"><?php echo count( $backup_codes ); ?></span>
+			<span><?php _e( ' unsused codes remaining.'); ?><span>
 		</p>
 		<div class="two-factor-backup-codes-wrapper" style="display:none;">
 			<ol class="two-factor-backup-codes-unused-codes"></ol>

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -168,20 +168,36 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 *
 	 * @since 0.1-dev
 	 *
-	 * @param int $user_id The logged-in user ID.
+	 * @param int   $user_id The logged-in user ID.
+	 * @param array $args Optional arguments for assinging new codes.
 	 */
-	public function generate_codes( $user_id ) {
+	public function generate_codes( $user_id, $args = '' ) {
+		$user = get_user_by('id', $user_id);
 		$codes = array();
 		$codes_hashed = array();
 
-		for ( $i = 0; $i < self::NUMBER_OF_CODES; $i++ ) {
+		// Check for arguments
+		if( isset( $args['number'] ) ) {
+			$num_codes = (int) $args['number'];
+		} else {
+			$num_codes = self::NUMBER_OF_CODES;
+		}
+
+		// Append or replace (default)
+		if( isset( $args['method'] ) && 'append' == $args['method'] ) {
+			//$num_existing_codes = self::codes_remaining_for_user( $user );
+			$codes_hashed = get_user_meta( $user->ID, self::BACKUP_CODES_META_KEY, true );
+			//$num_codes += $num_existing_codes;
+		}
+
+		for ( $i = 0; $i < $num_codes; $i++ ) {
 			$code = $this->get_code();
 			$codes_hashed[] = wp_hash_password( $code );
 			$codes[] = $code;
 			unset( $code );
 		}
 
-		update_user_meta( $user_id, self::BACKUP_CODES_META_KEY, $codes_hashed );
+		update_user_meta( $user->ID, self::BACKUP_CODES_META_KEY, $codes_hashed );
 
 		// Unhashed.
 		return $codes;

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -18,17 +18,16 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 
 	protected function __construct() {
 		//add_action( 'two-factor-user-options-' . __CLASS__, array( $this, 'user_options' ) );
-		add_action( 'admin_notices', array( __CLASS__, 'admin_notices' ) );
-		add_action( 'user_two_factor_options', array( __CLASS__, 'user_two_factor_options' ) );
-		add_action( 'wp_ajax_two_factor_backup_codes_generate', array( __CLASS__, 'ajax_generate_json' ) );
+		add_action( 'admin_notices', array( $this, 'admin_notices' ) );
+		add_action( 'user_two_factor_options', array( $this, 'user_two_factor_options' ) );
+		add_action( 'wp_ajax_two_factor_backup_codes_generate', array( $this, 'ajax_generate_json' ) );
 
 		return parent::__construct();
 	}
 
 	public static function admin_notices() {
-		$user_id = get_current_user_id();
-
 		// Only show this notice if we are out of backup codes
+		$user_id = get_current_user_id();
 		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
 		if( ! empty( $backup_codes ) ) {
 			return;

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -136,7 +136,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 						url: ajaxurl,
 						data:{
 							action:'two_factor_backup_codes_generate',
-							nonce: '<?php echo $ajax_nonce; ?>',
+							nonce: '<?php echo esc_js( $ajax_nonce ); ?>',
 						},
 						dataType: 'JSON',
 						success:function(data){

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -74,7 +74,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		?>
 		<div class="error">
 			<p>
-				<span><?php _e( 'Two-Factor: You are out of backup codes and need to '); ?><span>
+				<span><?php _e( 'Two-Factor: You are out of backup codes and need to ' ); ?><span>
 				<a href="<?php echo get_edit_user_link( $user->ID ); ?>#two-factor-backup-codes">regenerate!</a>
 			</p>
 		</div>
@@ -121,7 +121,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 				<?php esc_html_e( 'Generate Verification Codes' ); ?>
 			</button>
 			<span class="two-factor-backup-codes-count"><?php echo self::codes_remaining_for_user( $user ); ?></span>
-			<span><?php _e( ' unsused codes remaining.'); ?><span>
+			<span><?php _e( ' unsused codes remaining.' ); ?><span>
 		</p>
 		<div class="two-factor-backup-codes-wrapper" style="display:none;">
 			<ol class="two-factor-backup-codes-unused-codes"></ol>

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -123,7 +123,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	public function user_options( $user ) {
 		$user_id = $user->ID;
 		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
-		$ajax_nonce = wp_create_nonce( 'two-factor-backup-codes-generate-json' );
+		$ajax_nonce = wp_create_nonce( 'two-factor-backup-codes-generate-json-' . $user_id );
 		?>
 		<p id="two-factor-backup-codes">
 			<button type="button" class="button button-two-factor-backup-codes-generate button-secondary hide-if-no-js">
@@ -195,8 +195,8 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 * @since 0.1-dev
 	 */
 	public function ajax_generate_json() {
-		check_ajax_referer( 'two-factor-backup-codes-generate-json', 'nonce' );
 		$user_id = sanitize_text_field( $_REQUEST['user_id'] );
+		check_ajax_referer( 'two-factor-backup-codes-generate-json-' . $user_id, 'nonce' );
 		$codes = $this->generate_codes( $user_id );
 		wp_send_json_success( $codes );
 	}

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -30,9 +30,9 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 			return;
 		}
 		?>
-			<div class="error">
-				<p><?php _e( 'Two-Factor: You are out of backup codes and need to <a href="' . get_edit_user_link( $user_id ) . '#two-factor-backup-codes" >regenerate</a>!', 'two-factor' ); ?></p>
-			</div>
+		<div class="error">
+			<p><?php echo sprintf( __( 'Two-Factor: You are out of backup codes and need to <a href="%1$s#two-factor-backup-codes" >regenerate</a>!', 'two-factor' ), esc_url( get_edit_user_link( $user_id ) ) ); ?></p>
+		</div>
 		<?php
 	}
 
@@ -49,13 +49,16 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		$backup_codes = get_user_meta( $user_id, self::BACKUP_CODES_META_KEY, true );
 		$ajax_nonce = wp_create_nonce( 'two-factor-backup-codes-generate-json' );
 		?>
-		<p>
-			<button type="button" class="button button-two-factor-backup-codes-generate button-secondary hide-if-no-js">Generate Verification Codes</button>
-			<kbd><span class="two-factor-backup-codes-count"><?php echo count( $backup_codes ); ?></span> unused codes remaining.</kbd>
+		<p id="two-factor-backup-codes">
+			<button type="button" class="button button-two-factor-backup-codes-generate button-secondary hide-if-no-js">
+				<?php esc_html_e( 'Generate Verification Codes', 'two-factor' ); ?>
+			</button>
+			<?php echo sprintf( __( '<kbd><span class="two-factor-backup-codes-count">%1$s</span> unused codes remaining.</kbd>', 'two-factor' ), count( $backup_codes ) ); ?>
+
 		</p>
 		<div class="two-factor-backup-codes-wrapper" style="display:none;">
 			<ol class="two-factor-backup-codes-unused-codes"></ol>
-			<p class="description">Write 'em down y'all!</p>
+			<p class="description"><?php esc_html_e( "Write 'em down y'all!" , 'two-factor' ); ?></p>
 		</div>
 		<script type="text/javascript">
 			jQuery(document).ready(function($) {

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -57,7 +57,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		$user = wp_get_current_user();
 		$backup_codes = get_user_meta( $user->ID, self::BACKUP_CODES_META_KEY, true );
 
-		// Exit if we are not out of codes
+		// Exit if we are not out of codes.
 		if ( 0 < self::codes_remaining_for_user( $user ) ) {
 			return;
 		}
@@ -70,7 +70,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		<div class="error">
 			<p>
 				<span><?php esc_html_e( 'Two-Factor: You are out of backup codes and need to ' ); ?><span>
-				<a href="<?php echo get_edit_user_link( $user->ID ); ?>#two-factor-backup-codes">regenerate!</a>
+				<a href="<?php echo esc_url( get_edit_user_link( $user->ID ) ); ?>#two-factor-backup-codes">regenerate!</a>
 			</p>
 		</div>
 		<?php
@@ -115,8 +115,8 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 			<button type="button" class="button button-two-factor-backup-codes-generate button-secondary hide-if-no-js">
 				<?php esc_html_e( 'Generate Verification Codes' ); ?>
 			</button>
-			<span class="two-factor-backup-codes-count"><?php echo self::codes_remaining_for_user( $user ); ?></span>
-			<span><?php echo _n( ' unused code remaining.', ' unused codes remaining.', self::codes_remaining_for_user( $user ) ) ?><span>
+			<span class="two-factor-backup-codes-count"><?php echo esc_html( self::codes_remaining_for_user( $user ) ); ?></span>
+			<span><?php echo esc_html( _n( ' unused code remaining.', ' unused codes remaining.', self::codes_remaining_for_user( $user ) ) ); ?><span>
 		</p>
 		<div class="two-factor-backup-codes-wrapper" style="display:none;">
 			<ol class="two-factor-backup-codes-unused-codes"></ol>
@@ -157,7 +157,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 * @since 0.1-dev
 	 *
 	 * @param WP_User $user WP_User object of the logged-in user.
-	 * @param array $args Optional arguments for assinging new codes.
+	 * @param array   $args Optional arguments for assinging new codes.
 	 */
 	public function generate_codes( $user, $args = '' ) {
 		$codes = array();
@@ -254,8 +254,8 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 *
 	 * @since 0.1-dev
 	 *
-	 * @param WP_User $user WP_User object of the logged-in user.
-	 * @param int $code    The backup code.
+	 * @param  WP_User $user WP_User object of the logged-in user.
+	 * @param  int     $code The backup code.
 	 * @return boolean
 	 */
 	public function validate_code( $user, $code ) {

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -55,7 +55,6 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	public static function admin_notices() {
 		// Only show this notice if we are out of backup codes.
 		$user = wp_get_current_user();
-		$backup_codes = get_user_meta( $user->ID, self::BACKUP_CODES_META_KEY, true );
 
 		// Exit if we are not out of codes.
 		if ( 0 < self::codes_remaining_for_user( $user ) ) {


### PR DESCRIPTION
Adds the backup-codes provider to the list of potential methods.  Verification codes are single use and stored in the database as an array of hashed string.  Let me know if you have any questions.