### PR TITLE
Update plugin loading for phpunit

### DIFF
--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -20,9 +20,20 @@ if ( ! file_exists( $_tests_dir . '/includes/' ) ) {
 
 require_once $_tests_dir . '/includes/functions.php';
 
-// Activate the plugins.
-if ( defined( 'WP_TEST_ACTIVATED_PLUGINS' ) ) {
-	$GLOBALS['wp_tests_options']['active_plugins'] = explode( ',', WP_TEST_ACTIVATED_PLUGINS );
+function _manually_load_plugin() {
+	if ( defined( 'WP_TEST_ACTIVATED_PLUGINS' ) ) {
+		$active_plugins = get_option( 'active_plugins', array() );
+		$force_plugins = explode( ',', WP_TEST_ACTIVATED_PLUGINS );
+
+		foreach( $force_plugins as $plugin ) {
+			require dirname( __FILE__ ) . '/../../../../' . $plugin;
+
+			$active_plugins[] = $plugin;
+		}
+
+		update_option( 'active_plugins', $active_plugins );
+	}
 }
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 require $_tests_dir . '/includes/bootstrap.php';


### PR DESCRIPTION
Hi! I was trying to get the unit testing up and running, but hit a couple of snags. The main was was the use of is_plugin_active, which under my testing environment here wasn't registering two-factor/two-factor.php. I changed bootstrap to require the code and to set the active_plugins option. Does that seem fine? I wasn't able to find a spot where $GLOBALS['wp_tests_options']['active_plugins'] was actually used to load the plugins and update the option (maybe I missed it though).
Thanks! Looking forward to writing some tests. :)