### PR TITLE
Introduce a 2FA column on the Users admin listing screen

### DIFF
--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -40,6 +40,8 @@ class Two_Factor_Core {
 		add_action( 'edit_user_profile',        array( __CLASS__, 'user_two_factor_options' ) );
 		add_action( 'personal_options_update',  array( __CLASS__, 'user_two_factor_options_update' ) );
 		add_action( 'edit_user_profile_update', array( __CLASS__, 'user_two_factor_options_update' ) );
+		add_filter( 'manage_users_columns',       array( __CLASS__, 'filter_manage_users_columns' ) );
+		add_filter( 'manage_users_custom_column', array( __CLASS__, 'manage_users_custom_column' ), 10, 3 );
 	}
 
 	/**
@@ -445,6 +447,40 @@ class Two_Factor_Core {
 		wp_safe_redirect( $redirect_to );
 
 		exit;
+	}
+
+	/**
+	 * Filter the columns on the Users admin screen.
+	 *
+	 * @param  array $columns Available columns.
+	 * @return array          Updated array of columns.
+	 */
+	function filter_manage_users_columns( array $columns ) {
+		$columns['two-factor'] = __( 'Two-Factor' );
+		return $columns;
+	}
+
+	/**
+	 * Output the 2FA column data on the Users screen.
+	 *
+	 * @param  string $output      The column output.
+	 * @param  string $column_name The column ID.
+	 * @param  int    $user_id     The user ID.
+	 * @return string              The column output.
+	 */
+	function manage_users_custom_column( $output, $column_name, $user_id ) {
+
+		if ( 'two-factor' !== $column_name ) {
+			return $output;
+		}
+
+		if ( ! self::is_user_using_two_factor( $user_id ) ) {
+			return sprintf( '<span class="dashicons-before dashicons-no-alt">%s</span>', esc_html__( 'Disabled' ) );
+		} else {
+			$provider = self::get_primary_provider_for_user( $user_id );
+			return esc_html( $provider->get_label() );
+		}
+
 	}
 
 	/**

--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -455,7 +455,7 @@ class Two_Factor_Core {
 	 * @param  array $columns Available columns.
 	 * @return array          Updated array of columns.
 	 */
-	function filter_manage_users_columns( array $columns ) {
+	public static function filter_manage_users_columns( array $columns ) {
 		$columns['two-factor'] = __( 'Two-Factor' );
 		return $columns;
 	}
@@ -468,7 +468,7 @@ class Two_Factor_Core {
 	 * @param  int    $user_id     The user ID.
 	 * @return string              The column output.
 	 */
-	function manage_users_custom_column( $output, $column_name, $user_id ) {
+	public static function manage_users_custom_column( $output, $column_name, $user_id ) {
 
 		if ( 'two-factor' !== $column_name ) {
 			return $output;


### PR DESCRIPTION
Introduces a column on the Users admin listing screen which displays each user's 2FA status.

It displays either `Disabled` for users with no 2FA enabled, or it displays their primary 2FA provider name.