### PR TITLE
Remove <kbd> tags that are being escaped and displayed

### DIFF
--- a/providers/class.two-factor-email.php
+++ b/providers/class.two-factor-email.php
@@ -170,7 +170,7 @@ class Two_Factor_Email extends Two_Factor_Provider {
 		$email = $user->user_email;
 		?>
 		<div>
-			<?php echo esc_html( sprintf( __( 'Authentication codes will be sent to <kbd>%1$s</kbd>.' ), $email ) ); ?>
+			<?php echo esc_html( sprintf( __( 'Authentication codes will be sent to %1$s.' ), $email ) ); ?>
 		</div>
 		<?php
 	}


### PR DESCRIPTION
The `<kbd>` tags here are being displayed because they're being passed through esc_html(). I don't really think they're needed.