### PR TITLE
Add a dummy input.

### DIFF
--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -465,6 +465,7 @@ class Two_Factor_Core {
 		$primary_provider = get_user_meta( $user->ID, self::PROVIDER_USER_META_KEY, true );
 		wp_nonce_field( 'user_two_factor_options', '_nonce_user_two_factor_options', false );
 		?>
+		<input type="hidden" name="<?php echo esc_attr( self::ENABLED_PROVIDERS_USER_META_KEY ); ?>[]" value="<?php /* Dummy input so $_POST value is passed when no providers are enabled. */ ?>" />
 		<table class="form-table">
 			<tr>
 				<th>


### PR DESCRIPTION
Dummy input so $_POST value is passed when no providers are enabled.

Fixes #20

Alternate resolution to #21