### PR TITLE
Combine "out of codes" strings into one string for better translatability

### DIFF
--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -67,8 +67,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		?>
 		<div class="error">
 			<p>
-				<span><?php esc_html_e( 'Two-Factor: You are out of backup codes and need to ' ); ?><span>
-				<a href="<?php echo esc_url( get_edit_user_link( $user->ID ) . '#two-factor-backup-codes' ); ?>"><?php esc_html_e( 'regenerate!' ); ?></a>
+				<span><?php printf( __( 'Two-Factor: You are out of backup codes and need to <a href="%s">regenerate!</a>' ), esc_url( get_edit_user_link( $user->ID ) . '#two-factor-backup-codes' ) ); ?><span>
 			</p>
 		</div>
 		<?php

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -67,7 +67,10 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		?>
 		<div class="error">
 			<p>
-				<span><?php printf( __( 'Two-Factor: You are out of backup codes and need to <a href="%s">regenerate!</a>' ), esc_url( get_edit_user_link( $user->ID ) . '#two-factor-backup-codes' ) ); ?><span>
+				<span><?php printf( // WPCS: XSS OK
+					__( 'Two-Factor: You are out of backup codes and need to <a href="%s">regenerate!</a>' ),
+					esc_url( get_edit_user_link( $user->ID ) . '#two-factor-backup-codes' )
+				); ?><span>
 			</p>
 		</div>
 		<?php

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -67,7 +67,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		?>
 		<div class="error">
 			<p>
-				<span><?php printf( // WPCS: XSS OK
+				<span><?php printf( // WPCS: XSS OK.
 					__( 'Two-Factor: You are out of backup codes and need to <a href="%s">regenerate!</a>' ),
 					esc_url( get_edit_user_link( $user->ID ) . '#two-factor-backup-codes' )
 				); ?><span>


### PR DESCRIPTION
You can't break a single string or sentence into two parts, translate separately, and concatenate. This will make the string fully translatable.