### PR TITLE
Travis CI: Switch from WP 4.0 to /trunk testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ php:
 env:
   - WP_VERSION=latest WP_MULTISITE=0
   - WP_VERSION=latest WP_MULTISITE=1
-  - WP_VERSION=4.0 WP_MULTISITE=0
-  - WP_VERSION=4.0 WP_MULTISITE=1
+  - WP_VERSION=trunk WP_MULTISITE=0
+  - WP_VERSION=trunk WP_MULTISITE=1
 
 matrix:
   allow_failures:


### PR DESCRIPTION
No need to run Travis-CI tests with WordPress 4.0, but tests should be running against `/trunk`