### PR TITLE
This shouldn't need to be escaped, as any escaping should be done on the handler.

### DIFF
--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -63,7 +63,7 @@ class Two_Factor_Core {
 		// FIDO U2F is PHP 5.3+ only.
 		if ( version_compare( PHP_VERSION, '5.3.0', '<' ) ) {
 			unset( $providers['Two_Factor_FIDO_U2F'] );
-			trigger_error( sprintf(
+			trigger_error( sprintf( // WPCS: XSS OK.
 				__( 'FIDO U2F is not available because you are using PHP %s. (Requires 5.3 or greater)' ),
 				PHP_VERSION
 			) );


### PR DESCRIPTION
https://travis-ci.org/georgestephanis/two-factor/jobs/78647176

## PHP_CodeSniffer
/tmp/wordpress/src/wp-content/plugins/two-factor/class.two-factor-core.p
hp:67:105: error - Expected next thing to be an escaping function (see
Codex for 'Data Validation'), not ')'
(WordPress.XSS.EscapeOutput.OutputNotEscaped)
/tmp/wordpress/src/wp-content/plugins/two-factor/class.two-factor-core.p
hp:68:17: error - Expected next thing to be an escaping function (see
Codex for 'Data Validation'), not 'PHP_VERSION'
(WordPress.XSS.EscapeOutput.OutputNotEscaped)