### PR TITLE
Include a fix for alternate login forms.

### DIFF
--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -230,10 +230,6 @@ class Two_Factor_Core {
 	 * @param WP_User $user WP_User object of the logged-in user.
 	 */
 	public static function show_two_factor_login( $user ) {
-		if ( ! function_exists( 'login_header' ) ) {
-			require_once( ABSPATH . WPINC . '/functions.wp-login.php' );
-		}
-
 		if ( ! $user ) {
 			$user = wp_get_current_user();
 		}
@@ -304,10 +300,16 @@ class Two_Factor_Core {
 		$available_providers = self::get_available_providers_for_user( $user );
 		$backup_providers = array_diff_key( $available_providers, array( $provider_class => null ) );
 		$interim_login = isset( $_REQUEST['interim-login'] ); // WPCS: override ok.
+		$wp_login_url = wp_login_url();
 
 		$rememberme = 0;
 		if ( isset( $_REQUEST['rememberme'] ) && $_REQUEST['rememberme'] ) {
 			$rememberme = 1;
+		}
+
+		if ( ! function_exists( 'login_header' ) ) {
+			// We really should migrate login_header() out of `wp-login.php` so it can be called from an includes file.
+			include_once( TWO_FACTOR_DIR . 'includes/function.login-header.php' );
 		}
 
 		login_header();
@@ -317,7 +319,7 @@ class Two_Factor_Core {
 		}
 		?>
 
-		<form name="validate_2fa_form" id="loginform" action="<?php echo esc_url( site_url( 'wp-login.php?action=validate_2fa', 'login_post' ) ); ?>" method="post" autocomplete="off">
+		<form name="validate_2fa_form" id="loginform" action="<?php echo esc_url( set_url_scheme( add_query_arg( 'action', 'validate_2fa', $wp_login_url ), 'login_post' ) ); ?>" method="post" autocomplete="off">
 				<input type="hidden" name="provider"      id="provider"      value="<?php echo esc_attr( $provider_class ); ?>" />
 				<input type="hidden" name="wp-auth-id"    id="wp-auth-id"    value="<?php echo esc_attr( $user->ID ); ?>" />
 				<input type="hidden" name="wp-auth-nonce" id="wp-auth-nonce" value="<?php echo esc_attr( $login_nonce ); ?>" />
@@ -343,7 +345,7 @@ class Two_Factor_Core {
 										'wp-auth-nonce' => $login_nonce,
 										'redirect_to'   => $redirect_to,
 										'rememberme'    => $rememberme,
-									) ) ) ); ?>"><?php echo esc_html( sprintf( __( 'Or, use your backup method: %s &rarr;', 'two-factor' ), $backup_provider->get_label() ) ); ?></a></p>
+									) ), $wp_login_url ) ); ?>"><?php echo esc_html( sprintf( __( 'Or, use your backup method: %s &rarr;', 'two-factor' ), $backup_provider->get_label() ) ); ?></a></p>
 			</div>
 		<?php elseif ( 1 < count( $backup_providers ) ) : ?>
 			<div class="backup-methods-wrap">
@@ -357,7 +359,7 @@ class Two_Factor_Core {
 										'wp-auth-nonce' => $login_nonce,
 										'redirect_to'   => $redirect_to,
 										'rememberme'    => $rememberme,
-									) ) ) ); ?>"><?php $backup_provider->print_label(); ?></a></li>
+									) ), $wp_login_url ) ); ?>"><?php $backup_provider->print_label(); ?></a></li>
 					<?php endforeach; ?>
 				</ul>
 			</div>

--- a/includes/function.login-header.php
+++ b/includes/function.login-header.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Output the login page header.
+ *
+ * @param string   $title    Optional. WordPress login Page title to display in the `<title>` element.
+ *                           Default 'Log In'.
+ * @param string   $message  Optional. Message to display in header. Default empty.
+ * @param WP_Error $wp_error Optional. The error to pass. Default empty.
+ */
+function login_header( $title = 'Log In', $message = '', $wp_error = '' ) {
+	global $error, $interim_login, $action;
+
+	// Don't index any of these forms
+	add_action( 'login_head', 'wp_no_robots' );
+
+	if ( wp_is_mobile() )
+		add_action( 'login_head', 'wp_login_viewport_meta' );
+
+	if ( empty($wp_error) )
+		$wp_error = new WP_Error();
+
+	// Shake it!
+	$shake_error_codes = array( 'empty_password', 'empty_email', 'invalid_email', 'invalidcombo', 'empty_username', 'invalid_username', 'incorrect_password' );
+	/**
+	 * Filter the error codes array for shaking the login form.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param array $shake_error_codes Error codes that shake the login form.
+	 */
+	$shake_error_codes = apply_filters( 'shake_error_codes', $shake_error_codes );
+
+	if ( $shake_error_codes && $wp_error->get_error_code() && in_array( $wp_error->get_error_code(), $shake_error_codes ) )
+		add_action( 'login_head', 'wp_shake_js', 12 );
+
+	?><!DOCTYPE html>
+	<!--[if IE 8]>
+	<html xmlns="http://www.w3.org/1999/xhtml" class="ie8" <?php language_attributes(); ?>>
+	<![endif]-->
+	<!--[if !(IE 8) ]><!-->
+	<html xmlns="http://www.w3.org/1999/xhtml" <?php language_attributes(); ?>>
+	<!--<![endif]-->
+	<head>
+		<meta http-equiv="Content-Type" content="<?php bloginfo('html_type'); ?>; charset=<?php bloginfo('charset'); ?>" />
+		<title><?php bloginfo('name'); ?> &rsaquo; <?php echo $title; ?></title>
+		<?php
+
+		wp_admin_css( 'login', true );
+
+		/*
+		 * Remove all stored post data on logging out.
+		 * This could be added by add_action('login_head'...) like wp_shake_js(),
+		 * but maybe better if it's not removable by plugins
+		 */
+		if ( 'loggedout' == $wp_error->get_error_code() ) {
+			?>
+			<script>if("sessionStorage" in window){try{for(var key in sessionStorage){if(key.indexOf("wp-autosave-")!=-1){sessionStorage.removeItem(key)}}}catch(e){}};</script>
+			<?php
+		}
+
+		/**
+		 * Enqueue scripts and styles for the login page.
+		 *
+		 * @since 3.1.0
+		 */
+		do_action( 'login_enqueue_scripts' );
+		/**
+		 * Fires in the login page header after scripts are enqueued.
+		 *
+		 * @since 2.1.0
+		 */
+		do_action( 'login_head' );
+
+		if ( is_multisite() ) {
+			$login_header_url   = network_home_url();
+			$login_header_title = get_current_site()->site_name;
+		} else {
+			$login_header_url   = __( 'https://wordpress.org/' );
+			$login_header_title = __( 'Powered by WordPress' );
+		}
+
+		/**
+		 * Filter link URL of the header logo above login form.
+		 *
+		 * @since 2.1.0
+		 *
+		 * @param string $login_header_url Login header logo URL.
+		 */
+		$login_header_url = apply_filters( 'login_headerurl', $login_header_url );
+		/**
+		 * Filter the title attribute of the header logo above login form.
+		 *
+		 * @since 2.1.0
+		 *
+		 * @param string $login_header_title Login header logo title attribute.
+		 */
+		$login_header_title = apply_filters( 'login_headertitle', $login_header_title );
+
+		$classes = array( 'login-action-' . $action, 'wp-core-ui' );
+		if ( wp_is_mobile() )
+			$classes[] = 'mobile';
+		if ( is_rtl() )
+			$classes[] = 'rtl';
+		if ( $interim_login ) {
+			$classes[] = 'interim-login';
+			?>
+			<style type="text/css">html{background-color: transparent;}</style>
+			<?php
+
+			if ( 'success' ===  $interim_login )
+				$classes[] = 'interim-login-success';
+		}
+		$classes[] =' locale-' . sanitize_html_class( strtolower( str_replace( '_', '-', get_locale() ) ) );
+
+		/**
+		 * Filter the login page body classes.
+		 *
+		 * @since 3.5.0
+		 *
+		 * @param array  $classes An array of body classes.
+		 * @param string $action  The action that brought the visitor to the login page.
+		 */
+		$classes = apply_filters( 'login_body_class', $classes, $action );
+
+		?>
+	</head>
+	<body class="login <?php echo esc_attr( implode( ' ', $classes ) ); ?>">
+	<div id="login">
+		<h1><a href="<?php echo esc_url( $login_header_url ); ?>" title="<?php echo esc_attr( $login_header_title ); ?>" tabindex="-1"><?php bloginfo( 'name' ); ?></a></h1>
+	<?php
+
+	unset( $login_header_url, $login_header_title );
+
+	/**
+	 * Filter the message to display above the login form.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $message Login message text.
+	 */
+	$message = apply_filters( 'login_message', $message );
+	if ( !empty( $message ) )
+		echo $message . "\n";
+
+	// In case a plugin uses $error rather than the $wp_errors object
+	if ( !empty( $error ) ) {
+		$wp_error->add('error', $error);
+		unset($error);
+	}
+
+	if ( $wp_error->get_error_code() ) {
+		$errors = '';
+		$messages = '';
+		foreach ( $wp_error->get_error_codes() as $code ) {
+			$severity = $wp_error->get_error_data( $code );
+			foreach ( $wp_error->get_error_messages( $code ) as $error_message ) {
+				if ( 'message' == $severity )
+					$messages .= '	' . $error_message . "<br />\n";
+				else
+					$errors .= '	' . $error_message . "<br />\n";
+			}
+		}
+		if ( ! empty( $errors ) ) {
+			/**
+			 * Filter the error messages displayed above the login form.
+			 *
+			 * @since 2.1.0
+			 *
+			 * @param string $errors Login error message.
+			 */
+			echo '<div id="login_error">' . apply_filters( 'login_errors', $errors ) . "</div>\n";
+		}
+		if ( ! empty( $messages ) ) {
+			/**
+			 * Filter instructional messages displayed above the login form.
+			 *
+			 * @since 2.5.0
+			 *
+			 * @param string $messages Login messages.
+			 */
+			echo '<p class="message">' . apply_filters( 'login_messages', $messages ) . "</p>\n";
+		}
+	}
+} // End of login_header()


### PR DESCRIPTION
In situations where login_header() is inaccessible (because we’re on a
page other than wp-login.php because of a plugin or something) manually
redefine `login_header()` so we can call it there as well.

Also make sure we’re always submitting to the correct page and links go
to the correct page — `wp_login_url()` — if a plugin changes that, they
should also be reordering things to call the actions we use so that it
still works.

Resolves issues with WooCommerce logins from front-end pages. :+1:

Fixes #61