### PR TITLE
Pass WP_User object in 'show_user_security_settings'

### DIFF
--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -618,7 +618,7 @@ class Two_Factor_Core {
 		 *
 		 * @since 0.1-dev
 		 */
-		do_action( 'show_user_security_settings' );
+		do_action( 'show_user_security_settings', $user );
 	}
 
 	/**


### PR DESCRIPTION
This fixes:
* Trying to get property of non-object in
class.application-passwords.php on line 94
* Trying to get property of non-object in
class.application-passwords.php on line 98
* Trying to get property of non-object in
providers/class.two-factor-fido-u2f-admin.php on line 98
* Trying to get property of non-object in
providers/class.two-factor-fido-u2f-admin.php on line 101