### PR TITLE
Don't submit TOTP input values without user action

### DIFF
--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -74,7 +74,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		$this->admin_notices();
 		?>
 		<br />
-		<a href="javascript:;" onclick="jQuery('#two-factor-totp-options').toggle();"><?php esc_html_e( 'View Options &rarr;' ); ?></a>
+		<a href="javascript:;" onclick="jQuery('#two-factor-totp-options').toggle();jQuery('input[name^=two-factor-totp-]').prop( 'disabled', function(i, v) { return !v; } );"><?php esc_html_e( 'View Options &rarr;' ); ?></a>
 		<div id="two-factor-totp-options" style="display:none;">
 			<?php if ( empty( $key ) ) {
 				$key = $this->generate_key();
@@ -85,8 +85,8 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 				<p><?php esc_html_e( 'Please scan the QR code or manually enter the key, then enter an authentication code from your app in order to complete setup' ); ?></p>
 				<p>
 					<label for="two-factor-totp-authcode"><?php esc_html_e( 'Authentication Code:' ); ?></label>
-					<input type="hidden" name="two-factor-totp-key" value="<?php echo esc_attr( $key ) ?>" />
-					<input type="tel" name="two-factor-totp-authcode" id="two-factor-totp-authcode" class="input" value="" size="20" pattern="[0-9]*" />
+					<input type="hidden" name="two-factor-totp-key" value="<?php echo esc_attr( $key ) ?>" disabled />
+					<input type="tel" name="two-factor-totp-authcode" id="two-factor-totp-authcode" class="input" value="" size="20" pattern="[0-9]*" disabled />
 				</p>
 			<?php } else { ?>
 				<p class="success"><?php esc_html_e( 'Enabled' ); ?></p>

--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -102,7 +102,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	 * @param integer $user_id The user ID whose options are being updated.
 	 */
 	public function user_two_factor_options_update( $user_id ) {
-		if ( ! empty( $_POST['do_totp_authcode'] ) ) {
+		if ( ! empty( $_POST['do_totp_authcode'] ) && isset( $_POST['_nonce_user_two_factor_totp_options'] ) ) {
 			check_admin_referer( 'user_two_factor_totp_options', '_nonce_user_two_factor_totp_options' );
 
 			$current_key = get_user_meta( $user_id, self::SECRET_META_KEY, true );

--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -74,7 +74,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		$this->admin_notices();
 		?>
 		<br />
-		<a href="javascript:;" onclick="jQuery('#two-factor-totp-options').toggle();jQuery('input[name^=two-factor-totp-]').prop( 'disabled', function(i, v) { return !v; } );"><?php esc_html_e( 'View Options &rarr;' ); ?></a>
+		<a href="javascript:;" onclick="jQuery('#two-factor-totp-options').toggle();" class="hide-if-no-js"><?php esc_html_e( 'View Options &rarr;' ); ?></a>
 		<div id="two-factor-totp-options" style="display:none;">
 			<?php if ( empty( $key ) ) {
 				$key = $this->generate_key();
@@ -85,8 +85,9 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 				<p><?php esc_html_e( 'Please scan the QR code or manually enter the key, then enter an authentication code from your app in order to complete setup' ); ?></p>
 				<p>
 					<label for="two-factor-totp-authcode"><?php esc_html_e( 'Authentication Code:' ); ?></label>
-					<input type="hidden" name="two-factor-totp-key" value="<?php echo esc_attr( $key ) ?>" disabled />
-					<input type="tel" name="two-factor-totp-authcode" id="two-factor-totp-authcode" class="input" value="" size="20" pattern="[0-9]*" disabled />
+					<input type="hidden" name="two-factor-totp-key" value="<?php echo esc_attr( $key ) ?>" />
+					<input type="tel" name="two-factor-totp-authcode" id="two-factor-totp-authcode" class="input" value="" size="20" pattern="[0-9]*" />
+					<?php submit_button( __( 'Verify' ), 'secondary', 'do_totp_authcode', false ); ?>
 				</p>
 			<?php } else { ?>
 				<p class="success"><?php esc_html_e( 'Enabled' ); ?></p>
@@ -101,7 +102,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	 * @param integer $user_id The user ID whose options are being updated.
 	 */
 	public function user_two_factor_options_update( $user_id ) {
-		if ( isset( $_POST['_nonce_user_two_factor_totp_options'] ) ) {
+		if ( ! empty( $_POST['do_totp_authcode'] ) ) {
 			check_admin_referer( 'user_two_factor_totp_options', '_nonce_user_two_factor_totp_options' );
 
 			$current_key = get_user_meta( $user_id, self::SECRET_META_KEY, true );

--- a/tests/providers/class.two-factor-totp.php
+++ b/tests/providers/class.two-factor-totp.php
@@ -70,9 +70,13 @@ class Tests_Two_Factor_Totp extends WP_UnitTestCase {
 		$_POST[$request_key] = wp_create_nonce( 'user_two_factor_totp_options' );
 		$_REQUEST[$request_key] = $_POST[$request_key];
 
+		$_POST['do_totp_authcode'] = 'Verify';
+
 		ob_start();
 		$this->assertFalse( $this->provider->user_two_factor_options_update( $user->ID ) );
 		$content = ob_get_clean();
+
+		unset( $_POST['do_totp_authcode'] );
 
 		unset( $_REQUEST[$request_key] );
 		unset( $_POST[$request_key] );
@@ -91,6 +95,7 @@ class Tests_Two_Factor_Totp extends WP_UnitTestCase {
 		$_POST[$request_key] = wp_create_nonce( 'user_two_factor_totp_options' );
 		$_REQUEST[$request_key] = $_POST[$request_key];
 
+		$_POST['do_totp_authcode'] = 'Verify';
 		$_POST['two-factor-totp-key'] = $this->provider->generate_key();
 
 		ob_start();
@@ -98,6 +103,7 @@ class Tests_Two_Factor_Totp extends WP_UnitTestCase {
 		$content = ob_get_clean();
 
 		unset( $_POST['two-factor-totp-key'] );
+		unset( $_POST['do_totp_authcode'] );
 
 		unset( $_REQUEST[$request_key] );
 		unset( $_POST[$request_key] );
@@ -116,6 +122,7 @@ class Tests_Two_Factor_Totp extends WP_UnitTestCase {
 		$_POST[$request_key] = wp_create_nonce( 'user_two_factor_totp_options' );
 		$_REQUEST[$request_key] = $_POST[$request_key];
 
+		$_POST['do_totp_authcode'] = 'Verify';
 		$_POST['two-factor-totp-key'] = $this->provider->generate_key();
 		$_POST['two-factor-totp-authcode'] = 'bad_test_authcode';
 
@@ -125,6 +132,7 @@ class Tests_Two_Factor_Totp extends WP_UnitTestCase {
 
 		unset( $_POST['two-factor-totp-authcode'] );
 		unset( $_POST['two-factor-totp-key'] );
+		unset( $_POST['do_totp_authcode'] );
 
 		unset( $_REQUEST[$request_key] );
 		unset( $_POST[$request_key] );
@@ -144,6 +152,7 @@ class Tests_Two_Factor_Totp extends WP_UnitTestCase {
 		$_REQUEST[$request_key] = $_POST[$request_key];
 
 		$key = $this->provider->generate_key();
+		$_POST['do_totp_authcode'] = 'Verify';
 		$_POST['two-factor-totp-key'] = $key;
 		$_POST['two-factor-totp-authcode'] = $this->provider->calc_totp( $key );
 
@@ -153,6 +162,7 @@ class Tests_Two_Factor_Totp extends WP_UnitTestCase {
 
 		unset( $_POST['two-factor-totp-authcode'] );
 		unset( $_POST['two-factor-totp-key'] );
+		unset( $_POST['do_totp_authcode'] );
 
 		unset( $_REQUEST[$request_key] );
 		unset( $_POST[$request_key] );


### PR DESCRIPTION
This fixes #77

By disabling input element, its value won't be submitted to the server.
