### PR TITLE
For multisite uses, require network-wide

### DIFF
--- a/two-factor.php
+++ b/two-factor.php
@@ -6,6 +6,7 @@
  * Author: George Stephanis
  * Version: 0.1-dev
  * Author URI: http://stephanis.info
+ * Network: True
  */
 
 /**


### PR DESCRIPTION
Without requiring network-wide activation, the plugin can be bypassed by logging in via a site that hasn't enabled it.