### PR TITLE
Always use HTTPS and the TLD for the AppID

### DIFF
--- a/providers/class.two-factor-fido-u2f.php
+++ b/providers/class.two-factor-fido-u2f.php
@@ -101,6 +101,15 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 	public function authentication_page( $user ) {
 		require_once( ABSPATH . '/wp-admin/includes/template.php' );
 
+		// U2F doesn't work without HTTPS
+		if ( ! is_ssl() ) {
+			?>
+			<p><?php esc_html_e( 'U2F requires an HTTPS connection.' ); ?></p>
+			<?php
+
+			return;
+		}
+
 		try {
 			$keys = self::get_security_keys( $user->ID );
 			$data = self::$u2f->getAuthenticateData( $keys );

--- a/providers/class.two-factor-fido-u2f.php
+++ b/providers/class.two-factor-fido-u2f.php
@@ -53,11 +53,12 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 			return;
 		}
 
-		$app_url_parts = parse_url( home_url() );
-		$app_url = sprintf( '%s://%s', $app_url_parts['scheme'], $app_url_parts['host'] );
+		// U2F requires the AppID to use HTTPS and a top-level domain
+		$home_url_parts = wp_parse_url( home_url() );
+		$app_id = sprintf( 'https://%s', $home_url_parts['host'] );
 
 		require_once( TWO_FACTOR_DIR . 'includes/Yubico/U2F.php' );
-		self::$u2f = new u2flib_server\U2F( $app_url );
+		self::$u2f = new u2flib_server\U2F( $app_id );
 
 		require_once( TWO_FACTOR_DIR . 'providers/class.two-factor-fido-u2f-admin.php' );
 		Two_Factor_FIDO_U2F_Admin::add_hooks();


### PR DESCRIPTION
Fixes #123 and #118.

See https://developers.yubico.com/U2F/App_ID.html