### PR TITLE
Add missing text domains

### DIFF
--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -54,7 +54,7 @@ class Two_Factor_Core {
 	 * Sites on WordPress 4.6+ benefit from just-in-time loading of translations.
 	 */
 	public static function load_textdomain() {
-		load_plugin_textdomain( 'two-factor', false, plugin_dir_path( __FILE__ ) . '/languages' );
+		load_plugin_textdomain( 'two-factor', false, plugin_dir_path( __FILE__ ) . 'languages' );
 	}
 
 	/**

--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -35,6 +35,7 @@ class Two_Factor_Core {
 	 * @since 0.1-dev
 	 */
 	public static function add_hooks() {
+		add_action( 'init',                     array( __CLASS__, 'load_textdomain' ) );
 		add_action( 'init',                     array( __CLASS__, 'get_providers' ) );
 		add_action( 'wp_login',                 array( __CLASS__, 'wp_login' ), 10, 2 );
 		add_action( 'login_form_validate_2fa',  array( __CLASS__, 'login_form_validate_2fa' ) );
@@ -45,6 +46,15 @@ class Two_Factor_Core {
 		add_action( 'edit_user_profile_update', array( __CLASS__, 'user_two_factor_options_update' ) );
 		add_filter( 'manage_users_columns',       array( __CLASS__, 'filter_manage_users_columns' ) );
 		add_filter( 'manage_users_custom_column', array( __CLASS__, 'manage_users_custom_column' ), 10, 3 );
+	}
+
+	/**
+	 * Loads the plugin's text domain.
+	 *
+	 * Sites on WordPress 4.6+ benefit from just-in-time loading of translations.
+	 */
+	public static function load_textdomain() {
+		load_plugin_textdomain( 'two-factor', false, plugin_dir_path( __FILE__ ) . '/languages' );
 	}
 
 	/**

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -72,7 +72,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 				<span>
 					<?php
 					printf( // WPCS: XSS OK.
-						__( 'Two-Factor: You are out of backup codes and need to <a href="%s">regenerate!</a>' ),
+						__( 'Two-Factor: You are out of backup codes and need to <a href="%s">regenerate!</a>', 'two-factor' ),
 						esc_url( get_edit_user_link( $user->ID ) . '#two-factor-backup-codes' )
 					);
 					?>
@@ -88,7 +88,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 * @since 0.1-dev
 	 */
 	public function get_label() {
-		return _x( 'Backup Verification Codes (Single Use)', 'Provider Label' );
+		return _x( 'Backup Verification Codes (Single Use)', 'Provider Label', 'two-factor' );
 	}
 
 	/**
@@ -120,15 +120,21 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		?>
 		<p id="two-factor-backup-codes">
 			<button type="button" class="button button-two-factor-backup-codes-generate button-secondary hide-if-no-js">
-				<?php esc_html_e( 'Generate Verification Codes' ); ?>
+				<?php esc_html_e( 'Generate Verification Codes', 'two-factor' ); ?>
 			</button>
-			<span class="two-factor-backup-codes-count"><?php echo esc_html( sprintf( _n( '%s unused code remaining.', '%s unused codes remaining.', $count ), $count ) ); ?></span>
+			<span class="two-factor-backup-codes-count"><?php
+				echo esc_html( sprintf(
+					/* translators: %s: count */
+					_n( '%s unused code remaining.', '%s unused codes remaining.', $count, 'two-factor' ),
+					$count
+				) );
+				?></span>
 		</p>
 		<div class="two-factor-backup-codes-wrapper" style="display:none;">
 			<ol class="two-factor-backup-codes-unused-codes"></ol>
-			<p class="description"><?php esc_html_e( 'Write these down!  Once you navigate away from this page, you will not be able to view these codes again.' ); ?></p>
+			<p class="description"><?php esc_html_e( 'Write these down!  Once you navigate away from this page, you will not be able to view these codes again.', 'two-factor' ); ?></p>
 			<p>
-				<a class="button button-two-factor-backup-codes-download button-secondary hide-if-no-js"	 href="javascript:void(0);" id="two-factor-backup-codes-download-link" download="two-factor-backup-codes.txt"><?php esc_html_e( 'Download Codes' ); ?></a>
+				<a class="button button-two-factor-backup-codes-download button-secondary hide-if-no-js" href="javascript:void(0);" id="two-factor-backup-codes-download-link" download="two-factor-backup-codes.txt"><?php esc_html_e( 'Download Codes', 'two-factor' ); ?></a>
 			<p>
 		</div>
 		<script type="text/javascript">
@@ -224,8 +230,10 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		$codes = $this->generate_codes( $user );
 		$count = self::codes_remaining_for_user( $user );
 		$i18n = array(
-			'count' => esc_html( sprintf( _n( '%s unused code remaining.', '%s unused codes remaining.', $count ), $count ) ),
-			'title' => esc_html__( 'Two-Factor Backup Codes for %s' ),
+			/* translators: %s: count */
+			'count' => esc_html( sprintf( _n( '%s unused code remaining.', '%s unused codes remaining.', $count, 'two-factor' ), $count ) ),
+			/* translators: %s: the site's domain */
+			'title' => esc_html__( 'Two-Factor Backup Codes for %s', 'two-factor' ),
 		);
 
 		// Send the response.
@@ -256,13 +264,13 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	public function authentication_page( $user ) {
 		require_once( ABSPATH .  '/wp-admin/includes/template.php' );
 		?>
-		<p><?php esc_html_e( 'Enter a backup verification code.' ); ?></p><br/>
+		<p><?php esc_html_e( 'Enter a backup verification code.', 'two-factor' ); ?></p><br/>
 		<p>
-			<label for="authcode"><?php esc_html_e( 'Verification Code:' ); ?></label>
+			<label for="authcode"><?php esc_html_e( 'Verification Code:', 'two-factor' ); ?></label>
 			<input type="tel" name="two-factor-backup-code" id="authcode" class="input" value="" size="20" pattern="[0-9]*" />
 		</p>
 		<?php
-		submit_button( __( 'Submit' ) );
+		submit_button( __( 'Submit', 'two-factor' ) );
 	}
 
 	/**

--- a/providers/class.two-factor-dummy.php
+++ b/providers/class.two-factor-dummy.php
@@ -38,7 +38,7 @@ class Two_Factor_Dummy extends Two_Factor_Provider {
 	 * @since 0.1-dev
 	 */
 	public function get_label() {
-		return _x( 'Dummy Method', 'Provider Label' );
+		return _x( 'Dummy Method', 'Provider Label', 'two-factor' );
 	}
 
 	/**
@@ -51,9 +51,9 @@ class Two_Factor_Dummy extends Two_Factor_Provider {
 	public function authentication_page( $user ) {
 		require_once( ABSPATH .  '/wp-admin/includes/template.php' );
 		?>
-		<p><?php esc_html_e( 'Are you really you?' ); ?></p>
+		<p><?php esc_html_e( 'Are you really you?', 'two-factor' ); ?></p>
 		<?php
-		submit_button( __( 'Yup.' ) );
+		submit_button( __( 'Yup.', 'two-factor' ) );
 	}
 
 	/**

--- a/providers/class.two-factor-email.php
+++ b/providers/class.two-factor-email.php
@@ -45,7 +45,7 @@ class Two_Factor_Email extends Two_Factor_Provider {
 	 * @since 0.1-dev
 	 */
 	public function get_label() {
-		return _x( 'Email', 'Provider Label' );
+		return _x( 'Email', 'Provider Label', 'two-factor' );
 	}
 
 	/**
@@ -101,8 +101,10 @@ class Two_Factor_Email extends Two_Factor_Provider {
 	public function generate_and_email_token( $user ) {
 		$token = $this->generate_token( $user->ID );
 
-		$subject = wp_strip_all_tags( sprintf( __( 'Your login confirmation code for %s' ), get_bloginfo( 'name' ) ) );
-		$message = wp_strip_all_tags( sprintf( __( 'Enter %s to log in.' ), $token ) );
+		/* translators: %s: site name */
+		$subject = wp_strip_all_tags( sprintf( __( 'Your login confirmation code for %s', 'two-factor' ), get_bloginfo( 'name' ) ) );
+		/* translators: %s: token */
+		$message = wp_strip_all_tags( sprintf( __( 'Enter %s to log in.', 'two-factor' ), $token ) );
 		wp_mail( $user->user_email, $subject, $message );
 	}
 
@@ -121,9 +123,9 @@ class Two_Factor_Email extends Two_Factor_Provider {
 		$this->generate_and_email_token( $user );
 		require_once( ABSPATH .  '/wp-admin/includes/template.php' );
 		?>
-		<p><?php esc_html_e( 'A verification code has been sent to the email address associated with your account.' ); ?></p>
+		<p><?php esc_html_e( 'A verification code has been sent to the email address associated with your account.', 'two-factor' ); ?></p>
 		<p>
-			<label for="authcode"><?php esc_html_e( 'Verification Code:' ); ?></label>
+			<label for="authcode"><?php esc_html_e( 'Verification Code:', 'two-factor' ); ?></label>
 			<input type="tel" name="two-factor-email-code" id="authcode" class="input" value="" size="20" pattern="[0-9]*" />
 		</p>
 		<script type="text/javascript">
@@ -137,7 +139,7 @@ class Two_Factor_Email extends Two_Factor_Provider {
 			}, 200);
 		</script>
 		<?php
-		submit_button( __( 'Log In' ) );
+		submit_button( __( 'Log In', 'two-factor' ) );
 	}
 
 	/**
@@ -179,7 +181,13 @@ class Two_Factor_Email extends Two_Factor_Provider {
 		$email = $user->user_email;
 		?>
 		<div>
-			<?php echo esc_html( sprintf( __( 'Authentication codes will be sent to %1$s.' ), $email ) ); ?>
+			<?php
+			echo esc_html( sprintf(
+				/* translators: %s: email address */
+				__( 'Authentication codes will be sent to %s.', 'two-factor' ),
+				$email
+			) );
+			?>
 		</div>
 		<?php
 	}

--- a/providers/class.two-factor-fido-u2f-admin-list-table.php
+++ b/providers/class.two-factor-fido-u2f-admin-list-table.php
@@ -23,9 +23,9 @@ class Two_Factor_FIDO_U2F_Admin_List_Table extends WP_List_Table {
 	 */
 	public function get_columns() {
 		return array(
-			'name'      => wp_strip_all_tags( __( 'Name' ) ),
-			'added'   => wp_strip_all_tags( __( 'Added' ) ),
-			'last_used' => wp_strip_all_tags( __( 'Last Used' ) ),
+			'name'      => wp_strip_all_tags( __( 'Name', 'two-factor' ) ),
+			'added'   => wp_strip_all_tags( __( 'Added', 'two-factor' ) ),
+			'last_used' => wp_strip_all_tags( __( 'Last Used', 'two-factor' ) ),
 		);
 	}
 
@@ -127,10 +127,10 @@ class Two_Factor_FIDO_U2F_Admin_List_Table extends WP_List_Table {
 					<td colspan="<?php echo esc_attr( $this->get_column_count() ); ?>" class="colspanchange">
 						<fieldset>
 							<div class="inline-edit-col">
-								<h4><?php esc_html_e( 'Quick Edit' ); ?></h4>
+								<h4><?php esc_html_e( 'Quick Edit', 'two-factor' ); ?></h4>
 
 								<label>
-									<span class="title"><?php esc_html_e( 'Name' ); ?></span>
+									<span class="title"><?php esc_html_e( 'Name', 'two-factor' ); ?></span>
 									<span class="input-text-wrap"><input type="text" name="name" class="ptitle" value="" /></span>
 								</label>
 							</div>
@@ -148,8 +148,8 @@ class Two_Factor_FIDO_U2F_Admin_List_Table extends WP_List_Table {
 						}
 						?>
 						<p class="inline-edit-save submit">
-							<a href="#inline-edit" class="cancel button-secondary alignleft"><?php esc_html_e( 'Cancel' ); ?></a>
-							<a href="#inline-edit" class="save button-primary alignright"><?php esc_html_e( 'Update' ); ?></a>
+							<a href="#inline-edit" class="cancel button-secondary alignleft"><?php esc_html_e( 'Cancel', 'two-factor' ); ?></a>
+							<a href="#inline-edit" class="save button-primary alignright"><?php esc_html_e( 'Update', 'two-factor' ); ?></a>
 							<span class="spinner"></span>
 							<span class="error" style="display:none;"></span>
 							<?php wp_nonce_field( 'keyinlineeditnonce', '_inline_edit', false ); ?>

--- a/providers/class.two-factor-fido-u2f-admin.php
+++ b/providers/class.two-factor-fido-u2f-admin.php
@@ -83,8 +83,8 @@ class Two_Factor_FIDO_U2F_Admin {
 				'sigs' => $sigs,
 			),
 			'text' => array(
-				'insert' => esc_html__( 'Now insert (and tap) your Security Key.' ),
-				'error' => esc_html__( 'Failed...' ),
+				'insert' => esc_html__( 'Now insert (and tap) your Security Key.', 'two-factor' ),
+				'error' => esc_html__( 'Failed...', 'two-factor' ),
 			),
 		);
 
@@ -147,21 +147,21 @@ class Two_Factor_FIDO_U2F_Admin {
 
 		?>
 		<div class="security-keys" id="security-keys-section">
-			<h3><?php esc_html_e( 'Security Keys' ); ?></h3>
-			<p><?php esc_html_e( 'FIDO U2F is only supported in Chrome 41+.' ); ?></p>
-			<p><a href="https://support.google.com/accounts/answer/6103523"><?php esc_html_e( 'You can find FIDO U2F Security Key devices for sale from here.' ); ?></a></p>
+			<h3><?php esc_html_e( 'Security Keys', 'two-factor' ); ?></h3>
+			<p><?php esc_html_e( 'FIDO U2F is only supported in Chrome 41+.', 'two-factor' ); ?></p>
+			<p><a href="https://support.google.com/accounts/answer/6103523"><?php esc_html_e( 'You can find FIDO U2F Security Key devices for sale from here.', 'two-factor' ); ?></a></p>
 			<div class="register-security-key">
 				<?php if ( Two_Factor_FIDO_U2F::is_browser_support() ) : ?>
 				<input type="hidden" name="do_new_security_key" id="do_new_security_key" />
 				<input type="hidden" name="u2f_response" id="u2f_response" />
-				<button type="button" class="button button-secondary" id="register_security_key"><?php esc_html_e( 'Add New' ); ?></button>
+				<button type="button" class="button button-secondary" id="register_security_key"><?php echo esc_html( _x( 'Add New', 'security key', 'two-factor' ) ); ?></button>
 				<?php else : ?>
-				<p><?php esc_html_e( 'Your browser doesn\'t support FIDO U2F.' ); ?></p>
+				<p><?php esc_html_e( 'Your browser doesn not support FIDO U2F.', 'two-factor' ); ?></p>
 				<?php endif; ?>
 			</div>
 
 			<?php if ( $new_key ) : ?>
-			<p class="new-security-key"><?php esc_html_e( 'Your new security key registered.' ); ?></p>
+			<p class="new-security-key"><?php esc_html_e( 'Your new security key registered.', 'two-factor' ); ?></p>
 			<?php endif; ?>
 
 			<?php
@@ -245,7 +245,7 @@ class Two_Factor_FIDO_U2F_Admin {
 	 * @return string
 	 */
 	public static function rename_link( $item ) {
-		return sprintf( '<a href="#" class="editinline">%s</a>', esc_html__( 'Rename' ) );
+		return sprintf( '<a href="#" class="editinline">%s</a>', esc_html__( 'Rename', 'two-factor' ) );
 	}
 
 	/**
@@ -262,7 +262,7 @@ class Two_Factor_FIDO_U2F_Admin {
 	public static function delete_link( $item ) {
 		$delete_link = add_query_arg( 'delete_security_key', $item->keyHandle );
 		$delete_link = wp_nonce_url( $delete_link, "delete_security_key-{$item->keyHandle}", '_nonce_delete_security_key' );
-		return sprintf( '<a href="%1$s">%2$s</a>', esc_url( $delete_link ), esc_html__( 'Delete' ) );
+		return sprintf( '<a href="%1$s">%2$s</a>', esc_url( $delete_link ), esc_html__( 'Delete', 'two-factor' ) );
 	}
 
 	/**
@@ -300,7 +300,7 @@ class Two_Factor_FIDO_U2F_Admin {
 
 		$updated = Two_Factor_FIDO_U2F::update_security_key( $user_id, $key );
 		if ( ! $updated ) {
-			wp_die( esc_html__( 'Item not updated.' ) );
+			wp_die( esc_html__( 'Item not updated.', 'two-factor' ) );
 		}
 		$wp_list_table->single_row( $key );
 		wp_die();

--- a/providers/class.two-factor-fido-u2f-admin.php
+++ b/providers/class.two-factor-fido-u2f-admin.php
@@ -156,7 +156,7 @@ class Two_Factor_FIDO_U2F_Admin {
 				<input type="hidden" name="u2f_response" id="u2f_response" />
 				<button type="button" class="button button-secondary" id="register_security_key"><?php echo esc_html( _x( 'Add New', 'security key', 'two-factor' ) ); ?></button>
 				<?php else : ?>
-				<p><?php esc_html_e( 'Your browser doesn not support FIDO U2F.', 'two-factor' ); ?></p>
+				<p><?php esc_html_e( 'Your browser does not support FIDO U2F.', 'two-factor' ); ?></p>
 				<?php endif; ?>
 			</div>
 

--- a/providers/class.two-factor-fido-u2f.php
+++ b/providers/class.two-factor-fido-u2f.php
@@ -91,7 +91,7 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 	 * @since 0.1-dev
 	 */
 	public function get_label() {
-		return _x( 'FIDO U2F', 'Provider Label' );
+		return _x( 'FIDO U2F', 'Provider Label', 'two-factor' );
 	}
 
 	/**
@@ -120,7 +120,7 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 		// U2F doesn't work without HTTPS
 		if ( ! is_ssl() ) {
 			?>
-			<p><?php esc_html_e( 'U2F requires an HTTPS connection.' ); ?></p>
+			<p><?php esc_html_e( 'U2F requires an HTTPS connection.', 'two-factor' ); ?></p>
 			<?php
 
 			return;
@@ -132,12 +132,12 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 			update_user_meta( $user->ID, self::AUTH_DATA_USER_META_KEY, $data );
 		} catch ( Exception $e ) {
 			?>
-			<p><?php esc_html_e( 'An error occurred while creating authentication data.' ); ?></p>
+			<p><?php esc_html_e( 'An error occurred while creating authentication data.', 'two-factor' ); ?></p>
 			<?php
 			return null;
 		}
 		?>
-		<p><?php esc_html_e( 'Now insert (and tap) your Security Key.' ); ?></p>
+		<p><?php esc_html_e( 'Now insert (and tap) your Security Key.', 'two-factor' ); ?></p>
 		<input type="hidden" name="u2f_response" id="u2f_response" />
 		<script>
 			var u2fL10n = <?php echo wp_json_encode( array(
@@ -197,7 +197,7 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 	public function user_options( $user ) {
 		?>
 		<div>
-			<?php echo esc_html( __( 'You need to register security keys such as Yubikey.' ) ); ?>
+			<?php echo esc_html( __( 'You need to register security keys such as Yubikey.', 'two-factor' ) ); ?>
 		</div>
 		<?php
 	}
@@ -233,7 +233,7 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 			'counter'     => $register->counter,
 		);
 
-		$register['name']      = __( 'New Security Key' );
+		$register['name']      = __( 'New Security Key', 'two-factor' );
 		$register['added']     = current_time( 'timestamp' );
 		$register['last_used'] = $register['added'];
 

--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -56,7 +56,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	 * Returns the name of the provider.
 	 */
 	public function get_label() {
-		return _x( 'Time Based One-Time Password (Google Authenticator)', 'Provider Label' );
+		return _x( 'Time Based One-Time Password (Google Authenticator)', 'Provider Label', 'two-factor' );
 	}
 
 	/**
@@ -74,7 +74,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		$this->admin_notices();
 		?>
 		<br />
-		<a href="javascript:;" onclick="jQuery('#two-factor-totp-options').toggle();"><?php esc_html_e( 'View Options &rarr;' ); ?></a>
+		<a href="javascript:;" onclick="jQuery('#two-factor-totp-options').toggle();"><?php esc_html_e( 'View Options &rarr;', 'two-factor' ); ?></a>
 		<div id="two-factor-totp-options" style="display:none;">
 			<?php if ( empty( $key ) ) {
 				$key = $this->generate_key();
@@ -82,14 +82,14 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 				?>
 				<img src="<?php echo esc_url( $this->get_google_qr_code( $site_name . ':' . $user->user_login, $key, $site_name ) ); ?>" id="two-factor-totp-qrcode" />
 				<p><strong><?php echo esc_html( $key ); ?></strong></p>
-				<p><?php esc_html_e( 'Please scan the QR code or manually enter the key, then enter an authentication code from your app in order to complete setup' ); ?></p>
+				<p><?php esc_html_e( 'Please scan the QR code or manually enter the key, then enter an authentication code from your app in order to complete setup', 'two-factor' ); ?></p>
 				<p>
-					<label for="two-factor-totp-authcode"><?php esc_html_e( 'Authentication Code:' ); ?></label>
+					<label for="two-factor-totp-authcode"><?php esc_html_e( 'Authentication Code:', 'two-factor' ); ?></label>
 					<input type="hidden" name="two-factor-totp-key" value="<?php echo esc_attr( $key ) ?>" />
 					<input type="tel" name="two-factor-totp-authcode" id="two-factor-totp-authcode" class="input" value="" size="20" pattern="[0-9]*" />
 				</p>
 			<?php } else { ?>
-				<p class="success"><?php esc_html_e( 'Enabled' ); ?></p>
+				<p class="success"><?php esc_html_e( 'Enabled', 'two-factor' ); ?></p>
 			<?php } ?>
 		</div>
 		<?php
@@ -113,14 +113,14 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 			$notices = array();
 
 			if ( empty( $_POST['two-factor-totp-authcode'] ) ) {
-				$notices['error'][] = __( 'Two Factor Authentication not activated, you must specify authcode to ensure it is properly set up. Please re-scan the QR code and enter the code provided by your application.' );
+				$notices['error'][] = __( 'Two Factor Authentication not activated, you must specify authcode to ensure it is properly set up. Please re-scan the QR code and enter the code provided by your application.', 'two-factor' );
 			} else {
 				if ( $this->is_valid_authcode( $_POST['two-factor-totp-key'], $_POST['two-factor-totp-authcode'] ) ) {
 					if ( ! update_user_meta( $user_id, self::SECRET_META_KEY, $_POST['two-factor-totp-key'] ) ) {
-						$notices['error'][] = __( 'Unable to save Two Factor Authentication code. Please re-scan the QR code and enter the code provided by your application.' );
+						$notices['error'][] = __( 'Unable to save Two Factor Authentication code. Please re-scan the QR code and enter the code provided by your application.', 'two-factor' );
 					}
 				} else {
-					$notices['error'][] = __( 'Two Factor Authentication not activated, the authentication code you entered was not valid. Please re-scan the QR code and enter the code provided by your application.' );
+					$notices['error'][] = __( 'Two Factor Authentication not activated, the authentication code you entered was not valid. Please re-scan the QR code and enter the code provided by your application.', 'two-factor' );
 				}
 			}
 
@@ -322,7 +322,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		require_once( ABSPATH .  '/wp-admin/includes/template.php' );
 		?>
 		<p>
-			<label for="authcode"><?php esc_html_e( 'Authentication Code:' ); ?></label>
+			<label for="authcode"><?php esc_html_e( 'Authentication Code:', 'two-factor' ); ?></label>
 			<input type="tel" name="authcode" id="authcode" class="input" value="" size="20" pattern="[0-9]*" />
 		</p>
 		<script type="text/javascript">
@@ -336,7 +336,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 			}, 200);
 		</script>
 		<?php
-		submit_button( __( 'Authenticate' ) );
+		submit_button( __( 'Authenticate', 'two-factor' ) );
 	}
 
 	/**

--- a/tests/providers/class.two-factor-totp.php
+++ b/tests/providers/class.two-factor-totp.php
@@ -56,7 +56,7 @@ class Tests_Two_Factor_Totp extends WP_UnitTestCase {
 		$this->provider->user_two_factor_options( $user );
 		$content = ob_get_clean();
 
-		$this->assertContains( __( 'Authentication Code:' ), $content );
+		$this->assertContains( __( 'Authentication Code:', 'two-factor' ), $content );
 	}
 
 	/**

--- a/two-factor.php
+++ b/two-factor.php
@@ -7,6 +7,7 @@
  * Version: 0.1-dev
  * Author URI: http://stephanis.info
  * Network: True
+ * Text Domain: two-factor
  */
 
 /**


### PR DESCRIPTION
Also adds some translator comments and a `load_plugin_textdomain()` call to satisfy GlotPress. That way, the plugin can be properly translated using https://translate.wordpress.org.

Fixes #139.