### PR TITLE
Include URL protocol in the U2F AppID

### DIFF
--- a/providers/class.two-factor-fido-u2f.php
+++ b/providers/class.two-factor-fido-u2f.php
@@ -53,12 +53,8 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 			return;
 		}
 
-		// U2F requires the AppID to use HTTPS and a top-level domain
-		$home_url_parts = wp_parse_url( home_url() );
-		$app_id = sprintf( 'https://%s', $home_url_parts['host'] );
-
 		require_once( TWO_FACTOR_DIR . 'includes/Yubico/U2F.php' );
-		self::$u2f = new u2flib_server\U2F( $app_id );
+		self::$u2f = new u2flib_server\U2F( self::get_u2f_app_id() );
 
 		require_once( TWO_FACTOR_DIR . 'providers/class.two-factor-fido-u2f-admin.php' );
 		Two_Factor_FIDO_U2F_Admin::add_hooks();
@@ -83,6 +79,16 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 		add_action( 'two-factor-user-options-' . __CLASS__, array( $this, 'user_options' ) );
 
 		return parent::__construct();
+	}
+
+	/**
+	 * Return the U2F AppId.
+	 *
+	 * @return string AppID URI
+	 */
+	public static function get_u2f_app_id() {
+		// U2F requires the AppID to use HTTPS and a top-level domain.
+		return set_url_scheme( home_url(), 'https' );
 	}
 
 	/**

--- a/providers/class.two-factor-fido-u2f.php
+++ b/providers/class.two-factor-fido-u2f.php
@@ -82,13 +82,19 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 	}
 
 	/**
-	 * Return the U2F AppId.
+	 * Return the U2F AppId. U2F requires the AppID to use HTTPS
+	 * and a top-level domain.
 	 *
 	 * @return string AppID URI
 	 */
 	public static function get_u2f_app_id() {
-		// U2F requires the AppID to use HTTPS and a top-level domain.
-		return set_url_scheme( home_url(), 'https' );
+		$url_parts = wp_parse_url( home_url() );
+
+		if ( ! empty( $url_parts['port'] ) ) {
+			return sprintf( 'https://%s:%d', $url_parts['host'], $url_parts['port'] );
+		} else {
+			return sprintf( 'https://%s', $url_parts['host'] );
+		}
 	}
 
 	/**


### PR DESCRIPTION
A possible fix for #148.

I'm not sure about the following:

- Should we be using `home_url()` or `site_url()` for the AppID? Keeping the `home_url()` makes sense because it has worked well so far.

- Some sites might include extra path name in `home_url()` which wasn't there before this change. This will break their U2F login.

- How do we write unit tests for this? I would like to check that the output of `get_u2f_app_id()` always includes `https://`, for example.