### PR TITLE
Remove server-side U2F support detection

### DIFF
--- a/providers/class.two-factor-fido-u2f-admin-list-table.php
+++ b/providers/class.two-factor-fido-u2f-admin-list-table.php
@@ -82,20 +82,7 @@ class Two_Factor_FIDO_U2F_Admin_List_Table extends WP_List_Table {
 	 * @param string $which The location of the bulk actions: 'top' or 'bottom'.
 	 */
 	protected function display_tablenav( $which ) {
-		?>
-		<div class="tablenav <?php echo esc_attr( $which ); ?>">
-
-			<div class="alignleft actions bulkactions">
-				<?php $this->bulk_actions( $which ); ?>
-			</div>
-			<?php
-			$this->extra_tablenav( $which );
-			$this->pagination( $which );
-			?>
-
-			<br class="clear" />
-		</div>
-		<?php
+		// Not used for the Security key list.
 	}
 
 	/**

--- a/providers/class.two-factor-fido-u2f-admin.php
+++ b/providers/class.two-factor-fido-u2f-admin.php
@@ -85,7 +85,17 @@ class Two_Factor_FIDO_U2F_Admin {
 			),
 			'text' => array(
 				'insert' => esc_html__( 'Now insert (and tap) your Security Key.', 'two-factor' ),
-				'error' => esc_html__( 'Failed...', 'two-factor' ),
+				'error' => esc_html__( 'U2F request failed.', 'two-factor' ),
+				'error_codes' => array(
+					// Map u2f.ErrorCodes to error messages.
+					0 => esc_html__( 'Request OK.', 'two-factor' ),
+					1 => esc_html__( 'Other U2F error.', 'two-factor' ),
+					2 => esc_html__( 'Bad U2F request.', 'two-factor' ),
+					3 => esc_html__( 'Unsupported U2F configuration.', 'two-factor' ),
+					4 => esc_html__( 'U2F device ineligible.', 'two-factor' ),
+					5 => esc_html__( 'U2F request timeout reached.', 'two-factor' ),
+				),
+				'u2f_not_supported' => esc_html__( 'FIDO U2F is not supported in your web browser. Try using Google Chrome.', 'two-factor' ),
 			),
 		);
 

--- a/providers/class.two-factor-fido-u2f-admin.php
+++ b/providers/class.two-factor-fido-u2f-admin.php
@@ -70,7 +70,7 @@ class Two_Factor_FIDO_U2F_Admin {
 			'fido-u2f-admin',
 			plugins_url( 'js/fido-u2f-admin.js', __FILE__ ),
 			array( 'jquery', 'fido-u2f-api' ),
-			'0.1.0-dev.1',
+			'0.1.0-dev.2',
 			true
 		);
 
@@ -159,17 +159,22 @@ class Two_Factor_FIDO_U2F_Admin {
 		?>
 		<div class="security-keys" id="security-keys-section">
 			<h3><?php esc_html_e( 'Security Keys', 'two-factor' ); ?></h3>
-			<p><?php esc_html_e( 'FIDO U2F is only supported in Chrome 41+.', 'two-factor' ); ?></p>
-			<p><a href="https://support.google.com/accounts/answer/6103523"><?php esc_html_e( 'You can find FIDO U2F Security Key devices for sale from here.', 'two-factor' ); ?></a></p>
+
 			<div class="register-security-key">
 				<input type="hidden" name="do_new_security_key" id="do_new_security_key" />
 				<input type="hidden" name="u2f_response" id="u2f_response" />
-				<button type="button" class="button button-secondary" id="register_security_key"><?php echo esc_html( _x( 'Add New', 'security key', 'two-factor' ) ); ?></button>
+				<button type="button" class="button button-secondary" id="register_security_key"><?php echo esc_html( _x( 'Register New Key', 'security key', 'two-factor' ) ); ?></button>
+				<span class="spinner"></span>
+				<span class="security-key-status"></span>
 			</div>
 
 			<?php if ( $new_key ) : ?>
-			<p class="new-security-key"><?php esc_html_e( 'Your new security key registered.', 'two-factor' ); ?></p>
+			<div class="notice notice-success is-dismissible">
+				<p class="new-security-key"><?php esc_html_e( 'Your new security key registered.', 'two-factor' ); ?></p>
+			</div>
 			<?php endif; ?>
+
+			<p><a href="https://support.google.com/accounts/answer/6103523"><?php esc_html_e( 'You can find FIDO U2F Security Key devices for sale from here.', 'two-factor' ); ?></a></p>
 
 			<?php
 				require( TWO_FACTOR_DIR . 'providers/class.two-factor-fido-u2f-admin-list-table.php' );

--- a/providers/class.two-factor-fido-u2f-admin.php
+++ b/providers/class.two-factor-fido-u2f-admin.php
@@ -61,6 +61,11 @@ class Two_Factor_FIDO_U2F_Admin {
 			return false;
 		}
 
+		wp_enqueue_style(
+			'fido-u2f-admin',
+			plugins_url( 'css/fido-u2f-admin.css', __FILE__ )
+		);
+
 		wp_enqueue_script(
 			'fido-u2f-admin',
 			plugins_url( 'js/fido-u2f-admin.js', __FILE__ ),

--- a/providers/class.two-factor-fido-u2f-admin.php
+++ b/providers/class.two-factor-fido-u2f-admin.php
@@ -160,6 +160,10 @@ class Two_Factor_FIDO_U2F_Admin {
 		<div class="security-keys" id="security-keys-section">
 			<h3><?php esc_html_e( 'Security Keys', 'two-factor' ); ?></h3>
 
+			<?php if ( ! is_ssl() ) : ?>
+			<p><?php esc_html_e( 'U2F requires an HTTPS connection. You won\'t be able to add new security keys over HTTP.', 'two-factor' ); ?></p>
+			<?php endif; ?>
+
 			<div class="register-security-key">
 				<input type="hidden" name="do_new_security_key" id="do_new_security_key" />
 				<input type="hidden" name="u2f_response" id="u2f_response" />

--- a/providers/class.two-factor-fido-u2f-admin.php
+++ b/providers/class.two-factor-fido-u2f-admin.php
@@ -48,10 +48,6 @@ class Two_Factor_FIDO_U2F_Admin {
 			return;
 		}
 
-		if ( ! Two_Factor_FIDO_U2F::is_browser_support() ) {
-			return;
-		}
-
 		$user_id = get_current_user_id();
 		$security_keys = Two_Factor_FIDO_U2F::get_security_keys( $user_id );
 
@@ -151,13 +147,9 @@ class Two_Factor_FIDO_U2F_Admin {
 			<p><?php esc_html_e( 'FIDO U2F is only supported in Chrome 41+.', 'two-factor' ); ?></p>
 			<p><a href="https://support.google.com/accounts/answer/6103523"><?php esc_html_e( 'You can find FIDO U2F Security Key devices for sale from here.', 'two-factor' ); ?></a></p>
 			<div class="register-security-key">
-				<?php if ( Two_Factor_FIDO_U2F::is_browser_support() ) : ?>
 				<input type="hidden" name="do_new_security_key" id="do_new_security_key" />
 				<input type="hidden" name="u2f_response" id="u2f_response" />
 				<button type="button" class="button button-secondary" id="register_security_key"><?php echo esc_html( _x( 'Add New', 'security key', 'two-factor' ) ); ?></button>
-				<?php else : ?>
-				<p><?php esc_html_e( 'Your browser does not support FIDO U2F.', 'two-factor' ); ?></p>
-				<?php endif; ?>
 			</div>
 
 			<?php if ( $new_key ) : ?>

--- a/providers/class.two-factor-fido-u2f-admin.php
+++ b/providers/class.two-factor-fido-u2f-admin.php
@@ -161,7 +161,9 @@ class Two_Factor_FIDO_U2F_Admin {
 			<h3><?php esc_html_e( 'Security Keys', 'two-factor' ); ?></h3>
 
 			<?php if ( ! is_ssl() ) : ?>
-			<p><?php esc_html_e( 'U2F requires an HTTPS connection. You won\'t be able to add new security keys over HTTP.', 'two-factor' ); ?></p>
+			<p class="u2f-error-https">
+				<em><?php esc_html_e( 'U2F requires an HTTPS connection. You won\'t be able to add new security keys over HTTP.', 'two-factor' ); ?></em>
+			</p>
 			<?php endif; ?>
 
 			<div class="register-security-key">

--- a/providers/class.two-factor-fido-u2f-admin.php
+++ b/providers/class.two-factor-fido-u2f-admin.php
@@ -63,7 +63,9 @@ class Two_Factor_FIDO_U2F_Admin {
 
 		wp_enqueue_style(
 			'fido-u2f-admin',
-			plugins_url( 'css/fido-u2f-admin.css', __FILE__ )
+			plugins_url( 'css/fido-u2f-admin.css', __FILE__ ),
+			null,
+			'0.1.0-dev.1'
 		);
 
 		wp_enqueue_script(

--- a/providers/class.two-factor-fido-u2f.php
+++ b/providers/class.two-factor-fido-u2f.php
@@ -191,11 +191,13 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 	 * @param WP_User $user WP_User object of the logged-in user.
 	 */
 	public function user_options( $user ) {
-		?>
-		<div>
-			<?php echo esc_html( __( 'You need to register security keys such as Yubikey.', 'two-factor' ) ); ?>
-		</div>
-		<?php
+		if ( ! $this->is_available_for_user( $user ) ) {
+			?>
+			<p>
+				<?php echo esc_html__( 'Configure your security keys in the "Security Keys" section below.', 'two-factor' ); ?>
+			</p>
+			<?php
+		}
 	}
 
 	/**

--- a/providers/class.two-factor-fido-u2f.php
+++ b/providers/class.two-factor-fido-u2f.php
@@ -116,7 +116,7 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 		// U2F doesn't work without HTTPS
 		if ( ! is_ssl() ) {
 			?>
-			<p><?php esc_html_e( 'U2F requires an HTTPS connection.', 'two-factor' ); ?></p>
+			<p><?php esc_html_e( 'U2F requires an HTTPS connection. Please use an alternative 2nd factor method.', 'two-factor' ); ?></p>
 			<?php
 
 			return;

--- a/providers/class.two-factor-fido-u2f.php
+++ b/providers/class.two-factor-fido-u2f.php
@@ -100,10 +100,6 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 	 * @since 0.1-dev
 	 */
 	public function login_enqueue_assets() {
-		if ( ! self::is_browser_support() ) {
-			return;
-		}
-
 		wp_enqueue_script( 'fido-u2f-login' );
 	}
 
@@ -347,19 +343,5 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 		}
 
 		return true;
-	}
-
-	/**
-	 * Detect browser support for FIDO U2F.
-	 *
-	 * @since 0.1-dev
-	 */
-	public static function is_browser_support() {
-		global $is_chrome;
-
-		require_once( ABSPATH . '/wp-admin/includes/dashboard.php' );
-		$response = wp_check_browser_version();
-
-		return $is_chrome && version_compare( $response['version'], '41' ) >= 0 && ! wp_is_mobile();
 	}
 }

--- a/providers/class.two-factor-fido-u2f.php
+++ b/providers/class.two-factor-fido-u2f.php
@@ -91,7 +91,7 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 	 * @since 0.1-dev
 	 */
 	public function get_label() {
-		return _x( 'FIDO U2F', 'Provider Label', 'two-factor' );
+		return _x( 'FIDO Universal 2nd Factor (U2F)', 'Provider Label', 'two-factor' );
 	}
 
 	/**

--- a/providers/class.two-factor-fido-u2f.php
+++ b/providers/class.two-factor-fido-u2f.php
@@ -191,13 +191,11 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 	 * @param WP_User $user WP_User object of the logged-in user.
 	 */
 	public function user_options( $user ) {
-		if ( ! $this->is_available_for_user( $user ) ) {
-			?>
-			<p>
-				<?php echo esc_html__( 'Configure your security keys in the "Security Keys" section below.', 'two-factor' ); ?>
-			</p>
-			<?php
-		}
+		?>
+		<p>
+			<?php echo esc_html__( 'Configure your security keys in the "Security Keys" section below.', 'two-factor' ); ?>
+		</p>
+		<?php
 	}
 
 	/**

--- a/providers/class.two-factor-fido-u2f.php
+++ b/providers/class.two-factor-fido-u2f.php
@@ -193,7 +193,7 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 	public function user_options( $user ) {
 		?>
 		<p>
-			<?php echo esc_html__( 'Configure your security keys in the "Security Keys" section below.', 'two-factor' ); ?>
+			<?php esc_html_e( 'Requires an HTTPS connection. Configure your security keys in the "Security Keys" section below.', 'two-factor' ); ?>
 		</p>
 		<?php
 	}

--- a/providers/class.two-factor-fido-u2f.php
+++ b/providers/class.two-factor-fido-u2f.php
@@ -180,7 +180,7 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 	 * @return boolean
 	 */
 	public function is_available_for_user( $user ) {
-		return self::is_browser_support() && (bool) self::get_security_keys( $user->ID );
+		return (bool) self::get_security_keys( $user->ID );
 	}
 
 	/**

--- a/providers/css/fido-u2f-admin.css
+++ b/providers/css/fido-u2f-admin.css
@@ -1,0 +1,10 @@
+#security-keys-section .wp-list-table {
+	margin-bottom: 2em;
+}
+#security-keys-section .register-security-key .spinner {
+	float: none;
+}
+#security-keys-section .security-key-status {
+	vertical-align: middle;
+	font-style: italic;
+}

--- a/providers/js/fido-u2f-admin.js
+++ b/providers/js/fido-u2f-admin.js
@@ -23,6 +23,7 @@
 
 		$( this ).prop( 'disabled', true );
 		$( '.register-security-key .spinner' ).addClass( 'is-active' );
+		$status_notice.text( '' );
 
 		registerRequest = {
 			version: u2fL10n.register.request.version,

--- a/providers/js/fido-u2f-admin.js
+++ b/providers/js/fido-u2f-admin.js
@@ -1,7 +1,7 @@
 /* global u2f, u2fL10n */
 ( function( $ ) {
 	var $button = $( '#register_security_key' );
-	var $status_notice = $( '#security-keys-section .security-key-status' )
+	var $status_notice = $( '#security-keys-section .security-key-status' );
 	var u2f_supported = false;
 
 	$status_notice.text( u2fL10n.text.u2f_not_supported );

--- a/providers/js/fido-u2f-admin.js
+++ b/providers/js/fido-u2f-admin.js
@@ -1,21 +1,28 @@
 /* global u2f, u2fL10n */
 ( function( $ ) {
 	var $button = $( '#register_security_key' );
+	var $status_notice = $( '#security-keys-section .security-key-status' )
+	var u2f_supported = false;
+
+	$status_notice.text( u2fL10n.text.u2f_not_supported );
+
+	u2f.getApiVersion( function() {
+		u2f_supported = true;
+
+		$status_notice.text( '' );
+	} );
 
 	$button.click( function() {
 		var registerRequest;
 
-		if ( $button.hasClass( 'clicked' ) ) {
+		if ( $( this ).prop( 'disabled' ) ) {
 			return false;
-		} else {
-			$button.addClass( 'clicked' );
 		}
 
 		window.console.log( 'sign', u2fL10n.register.request );
 
-		$button.text( u2fL10n.text.insert ).append( '<span class="spinner is-active" />' );
-
-		$( '.spinner.is-active', $button ).css( 'margin', '2.5px 0px 0px 5px' );
+		$( this ).prop( 'disabled', true );
+		$( '.register-security-key .spinner' ).addClass( 'is-active' );
 
 		registerRequest = {
 			version: u2fL10n.register.request.version,
@@ -23,10 +30,18 @@
 		};
 
 		u2f.register( u2fL10n.register.request.appId, [ registerRequest ], u2fL10n.register.sigs, function( data ) {
+			$( '.register-security-key .spinner' ).removeClass( 'is-active' );
+			$button.prop( 'disabled', false );
+
 			if ( data.errorCode ) {
 				window.console.log( 'Registration Failed', data.errorCode );
 
-				$button.text( u2fL10n.text.error );
+				if ( u2fL10n.text.error_codes[ data.errorCode ] ) {
+					$status_notice.text( u2fL10n.text.error_codes[ data.errorCode ] );
+				} else {
+					$status_notice.text( u2fL10n.text.error_codes[ u2fL10n.text.error ] );
+				}
+
 				return false;
 			}
 

--- a/providers/js/fido-u2f-admin.js
+++ b/providers/js/fido-u2f-admin.js
@@ -1,15 +1,15 @@
 /* global u2f, u2fL10n */
 ( function( $ ) {
 	var $button = $( '#register_security_key' );
-	var $status_notice = $( '#security-keys-section .security-key-status' );
+	var $statusNotice = $( '#security-keys-section .security-key-status' );
 	var u2f_supported = false;
 
-	$status_notice.text( u2fL10n.text.u2f_not_supported );
+	$statusNotice.text( u2fL10n.text.u2f_not_supported );
 
 	u2f.getApiVersion( function() {
 		u2f_supported = true;
 
-		$status_notice.text( '' );
+		$statusNotice.text( '' );
 	} );
 
 	$button.click( function() {
@@ -23,7 +23,7 @@
 
 		$( this ).prop( 'disabled', true );
 		$( '.register-security-key .spinner' ).addClass( 'is-active' );
-		$status_notice.text( '' );
+		$statusNotice.text( '' );
 
 		registerRequest = {
 			version: u2fL10n.register.request.version,
@@ -38,9 +38,9 @@
 				window.console.log( 'Registration Failed', data.errorCode );
 
 				if ( u2fL10n.text.error_codes[ data.errorCode ] ) {
-					$status_notice.text( u2fL10n.text.error_codes[ data.errorCode ] );
+					$statusNotice.text( u2fL10n.text.error_codes[ data.errorCode ] );
 				} else {
-					$status_notice.text( u2fL10n.text.error_codes[ u2fL10n.text.error ] );
+					$statusNotice.text( u2fL10n.text.error_codes[ u2fL10n.text.error ] );
 				}
 
 				return false;

--- a/providers/js/fido-u2f-admin.js
+++ b/providers/js/fido-u2f-admin.js
@@ -2,12 +2,12 @@
 ( function( $ ) {
 	var $button = $( '#register_security_key' );
 	var $statusNotice = $( '#security-keys-section .security-key-status' );
-	var u2f_supported = false;
+	var u2fSupported = false;
 
 	$statusNotice.text( u2fL10n.text.u2f_not_supported );
 
 	u2f.getApiVersion( function() {
-		u2f_supported = true;
+		u2fSupported = true;
 
 		$statusNotice.text( '' );
 	} );

--- a/tests/providers/class.two-factor-fido-u2f.php
+++ b/tests/providers/class.two-factor-fido-u2f.php
@@ -31,7 +31,7 @@ class Tests_Two_Factor_FIDO_U2F extends WP_UnitTestCase {
 	 * Verify the label value.
 	 */
 	function test_get_label() {
-		$this->assertContains( 'FIDO U2F', $this->provider->get_label() );
+		$this->assertContains( 'FIDO Universal 2nd Factor (U2F)', $this->provider->get_label() );
 	}
 
 	function test_add_security_key() {


### PR DESCRIPTION
Fixes #117 and #78 . Ready for code review.

- Removes all PHP based U2F support detection.
- Introduce error handling when registering new keys.

Here is a notification if U2F browser support can't be detected:

![utf-not-supported-notice](https://cloud.githubusercontent.com/assets/169055/24396703/c6b4b59e-13ac-11e7-9555-8fc27eedb3be.png)

Here are the HTTPS related notifications:

![https-notification](https://cloud.githubusercontent.com/assets/169055/24398065/e80ee79c-13b0-11e7-81ec-c748022c4145.png)
