### PR TITLE
Better U2F Support Detection

### DIFF
--- a/includes/Google/u2f-api.js
+++ b/includes/Google/u2f-api.js
@@ -17,6 +17,12 @@
 var u2f = u2f || {};
 
 /**
+ * Check if browser supports U2F API before this wrapper was added.
+ * @type {int}
+ */
+var u2f.HasNativeApiSupport = ( u2f && u2f.register );
+
+/**
  * FIDO U2F Javascript API Version
  * @number
  */

--- a/includes/Google/u2f-api.js
+++ b/includes/Google/u2f-api.js
@@ -20,7 +20,7 @@ var u2f = u2f || {};
  * Check if browser supports U2F API before this wrapper was added.
  * @type {int}
  */
-var u2f.HasNativeApiSupport = ( u2f && u2f.register );
+u2f.HasNativeApiSupport = ( u2f && u2f.register );
 
 /**
  * FIDO U2F Javascript API Version

--- a/includes/Google/u2f-api.js
+++ b/includes/Google/u2f-api.js
@@ -20,7 +20,7 @@ var u2f = u2f || {};
  * Check if browser supports U2F API before this wrapper was added.
  * @type {int}
  */
-u2f.HasNativeApiSupport = ( u2f && u2f.register );
+u2f.HasNativeApiSupport = ( ( u2f && u2f.register ) || ( chrome && chrome.runtime ) );
 
 /**
  * FIDO U2F Javascript API Version

--- a/providers/class.two-factor-fido-u2f-admin.php
+++ b/providers/class.two-factor-fido-u2f-admin.php
@@ -72,7 +72,7 @@ class Two_Factor_FIDO_U2F_Admin {
 			'fido-u2f-admin',
 			plugins_url( 'js/fido-u2f-admin.js', __FILE__ ),
 			array( 'jquery', 'fido-u2f-api' ),
-			'0.1.0-dev.2',
+			'0.1.0-dev.3',
 			true
 		);
 

--- a/providers/class.two-factor-fido-u2f.php
+++ b/providers/class.two-factor-fido-u2f.php
@@ -63,7 +63,7 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 			'fido-u2f-api',
 			plugins_url( 'includes/Google/u2f-api.js', dirname( __FILE__ ) ),
 			null,
-			'0.1.0-dev.1',
+			'0.1.0-dev.2',
 			true
 		);
 

--- a/providers/js/fido-u2f-admin.js
+++ b/providers/js/fido-u2f-admin.js
@@ -2,15 +2,11 @@
 ( function( $ ) {
 	var $button = $( '#register_security_key' );
 	var $statusNotice = $( '#security-keys-section .security-key-status' );
-	var u2fSupported = false;
+	var u2fSupported = ( u2f && u2f.HasNativeApiSupport );
 
-	$statusNotice.text( u2fL10n.text.u2f_not_supported );
-
-	u2f.getApiVersion( function() {
-		u2fSupported = true;
-
-		$statusNotice.text( '' );
-	} );
+	if ( ! u2fSupported ) {
+		$statusNotice.text( u2fL10n.text.u2f_not_supported );
+	}
 
 	$button.click( function() {
 		var registerRequest;


### PR DESCRIPTION
Fixes #165.

Unfortunately there is no official way to detect U2F API support in web browsers. However, in reality only Chrome and Firefox can support U2F.

Chrome supports U2F natively via [`chrome.runtime.sendMessage()`](https://github.com/georgestephanis/two-factor/blob/8b03e926aeee703d8368b108040342f48538592b/includes/Google/u2f-api.js#L196-L206) so we can simply check for `chrome.runtime` and assume that it does support U2F.

The [Firefox U2F extension](https://addons.mozilla.org/en-US/firefox/addon/u2f-support-add-on/) works by [creating a global `window.u2f` object](https://github.com/prefiks/u2f4moz/blob/ab97706a178a3299a6568bab7dcdd320108c870f/ext/data/content-script.js#L120) that maps to its internal functions. So we check if `window.u2f` exists before adding the wrapper in `u2f-api.js`.

## Chrome

![chrome-ok](https://cloud.githubusercontent.com/assets/169055/24511978/f3ee07b6-1575-11e7-9f62-6d52bf4263c5.png)

## Firefox with Extension

![firefox-ok](https://cloud.githubusercontent.com/assets/169055/24511986/f940b0ec-1575-11e7-9b5c-f0e5389946df.png)

## Safari

![safari-fail](https://cloud.githubusercontent.com/assets/169055/24511995/feb33d24-1575-11e7-830a-e94ba915d503.png)

