### PR TITLE
Make 'Log In' button default on verification form

### DIFF
--- a/providers/class.two-factor-email.php
+++ b/providers/class.two-factor-email.php
@@ -176,6 +176,7 @@ class Two_Factor_Email extends Two_Factor_Provider {
 		<p>
 			<label for="authcode"><?php esc_html_e( 'Verification Code:', 'two-factor' ); ?></label>
 			<input type="tel" name="two-factor-email-code" id="authcode" class="input" value="" size="20" pattern="[0-9]*" />
+			<?php submit_button( __( 'Log In', 'two-factor' ) ); ?>
 		</p>
 		<p class="two-factor-email-resend">
 			<input type="submit" class="button" name="<?php echo esc_attr( self::INPUT_NAME_RESEND_CODE ); ?>" value="<?php esc_attr_e( 'Resend Code', 'two-factor' ); ?>" />
@@ -191,7 +192,6 @@ class Two_Factor_Email extends Two_Factor_Provider {
 			}, 200);
 		</script>
 		<?php
-		submit_button( __( 'Log In', 'two-factor' ) );
 	}
 
 	/**


### PR DESCRIPTION
On the Verification Code screen, currently if you
press return after typing/pasting the code,
'Resend Code' is the submit button that is triggered,
rather than 'Log In', which is confusing for users
as nothing appears to happen when they've provided
the correct code, yet they see ever growing incoming
emails (in the case of email verification).  For
most users Log In would be the expected behaviour.

Similarly, when you tab, Resend Code is the first
button rather than login.

Fixed by changing the order of the buttons in the
HTML (this also makes buttons horizontally aligned).