### PR TITLE
Add 2fa info column to network admins user list table

### DIFF
--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -45,6 +45,7 @@ class Two_Factor_Core {
 		add_action( 'personal_options_update', array( __CLASS__, 'user_two_factor_options_update' ) );
 		add_action( 'edit_user_profile_update', array( __CLASS__, 'user_two_factor_options_update' ) );
 		add_filter( 'manage_users_columns', array( __CLASS__, 'filter_manage_users_columns' ) );
+		add_filter( 'wpmu_users_columns', array( __CLASS__, 'filter_manage_users_columns' ) );
 		add_filter( 'manage_users_custom_column', array( __CLASS__, 'manage_users_custom_column' ), 10, 3 );
 	}
 


### PR DESCRIPTION
PR adds a filter on `wpmu_users_columns` so the 2fa info shows when looking at the users in the network admin on a multisite install. I think it's even more important to get an easy overview there compared to on a single site so one can see if all super admins have 2fa activated. :)