### PR TITLE
Allow plugin to be installed in wordpress through composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,6 @@
 {
+	"type": "wordpress-plugin",
+    "name": "two-factor"
     "require-dev": {
         "php-coveralls/php-coveralls": "^1.0"
     }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-	"type": "wordpress-plugin",
-    "name": "two-factor"
+    "type": "wordpress-plugin",
+    "name": "two-factor",
     "require-dev": {
         "php-coveralls/php-coveralls": "^1.0"
     }


### PR DESCRIPTION
By adding the `"type": "wordpress-plugin"` we can install the plugin to the plugins folder with composer. https://getcomposer.org/doc/04-schema.md#type