### PR TITLE
Add vendor to name property in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "type": "wordpress-plugin",
-    "name": "two-factor",
+    "name": "georgestephanis/two-factor",
     "require-dev": {
         "php-coveralls/php-coveralls": "^1.0"
     }


### PR DESCRIPTION
When adding the package as a mirror in packagist.com you get:
>Validation errors for https://github.com/georgestephanis/two-factor: The package name two-factor is invalid, it should have a vendor name, a forward slash, and a package name. The vendor and package name can be words separated by -, . or \_. The complete name should match "[a-z0-9]\([\_.-]?[a-z0-9]+)\*/[a-z0-9]\([\_.-]?[a-z0-9]+)\*".