### PR TITLE
Add description property in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "type": "wordpress-plugin",
     "name": "georgestephanis/two-factor",
+    "description": "Two-Factor Authentication for WordPress.",
     "require-dev": {
         "php-coveralls/php-coveralls": "^1.0"
     }


### PR DESCRIPTION
Running `composer validate`:
```
./composer.json is valid for simple usage with composer but has
strict errors that make it unable to be published as a package:
See https://getcomposer.org/doc/04-schema.md for details on the schema
description : The property description is required
No license specified, it is recommended to do so. For closed-source software you may use "proprietary" as license.
```

I couln't find license information so I skipped the property.

#237 is related, sorry for not proposing this as a whole.