### PR TITLE
Add support for deleting TOTP keys

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,7 +6,7 @@
 
 	<rule ref="WordPress-Core">
 		<exclude name="Generic.Formatting.MultipleStatementAlignment" />
-	<rule>
+	</rule>
 	<rule ref="WordPress-Docs">
 		<exclude name="Squiz.Commenting.FileComment.MissingPackageTag"/>
 		<exclude name="Squiz.Commenting.FileComment.Missing"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,7 +4,9 @@
 
 	<config name="installed_paths" value="vendor/wp-coding-standards/wpcs" />
 
-	<rule ref="WordPress-Core"/>
+	<rule ref="WordPress-Core">
+		<exclude name="Generic.Formatting.MultipleStatementAlignment" />
+	<rule>
 	<rule ref="WordPress-Docs">
 		<exclude name="Squiz.Commenting.FileComment.MissingPackageTag"/>
 		<exclude name="Squiz.Commenting.FileComment.Missing"/>

--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -137,7 +137,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 			if ( ! empty( $_POST['two-factor-totp-authcode'] ) && ! empty( $_POST['two-factor-totp-key'] ) ) {
 				if ( $this->is_valid_key( $_POST['two-factor-totp-key'] ) ) {
 					if ( $this->is_valid_authcode( $_POST['two-factor-totp-key'], $_POST['two-factor-totp-authcode'] ) ) {
-						if ( ! $this->set_user_totp_key( $user_id, $key ) ) {
+						if ( ! $this->set_user_totp_key( $user_id, $_POST['two-factor-totp-key'] ) ) {
 							$errors[] = __( 'Unable to save Two Factor Authentication code. Please re-scan the QR code and enter the code provided by your application.', 'two-factor' );
 						}
 					} else {

--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -88,12 +88,14 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 				<strong><?php echo esc_html( $key ); ?></strong>
 			</p>
 			<p>
-				<?php esc_html_e( 'Please scan the QR code or manually enter the key, then enter an authentication code from your app in order to complete setup', 'two-factor' ); ?>
+				<?php esc_html_e( 'Please scan the QR code or manually enter the key, then enter an authentication code from your app in order to complete setup.', 'two-factor' ); ?>
 			</p>
 			<p>
-				<label for="two-factor-totp-authcode"><?php esc_html_e( 'Authentication Code:', 'two-factor' ); ?></label>
 				<input type="hidden" name="two-factor-totp-key" value="<?php echo esc_attr( $key ) ?>" />
-				<input type="tel" name="two-factor-totp-authcode" id="two-factor-totp-authcode" class="input" value="" size="20" pattern="[0-9]*" />
+				<label for="two-factor-totp-authcode">
+					<?php esc_html_e( 'Authentication Code:', 'two-factor' ); ?>
+					<input type="tel" name="two-factor-totp-authcode" id="two-factor-totp-authcode" class="input" value="" size="20" pattern="[0-9]*" />
+				</label>
 				<input type="submit" class="button" name="two-factor-totp-submit" value="<?php esc_attr_e( 'Submit', 'two-factor' ); ?>" />
 			</p>
 		<?php else : ?>

--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -85,7 +85,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 				<img src="<?php echo esc_url( $this->get_google_qr_code( $site_name . ':' . $user->user_login, $key, $site_name ) ); ?>" id="two-factor-totp-qrcode" />
 			</p>
 			<p>
-				<strong><?php echo esc_html( $key ); ?></strong>
+				<code><?php echo esc_html( $key ); ?></code>
 			</p>
 			<p>
 				<?php esc_html_e( 'Please scan the QR code or manually enter the key, then enter an authentication code from your app in order to complete setup.', 'two-factor' ); ?>

--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -91,7 +91,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 				<code><?php echo esc_html( $key ); ?></code>
 			</p>
 			<p>
-				<input type="hidden" name="two-factor-totp-key" value="<?php echo esc_attr( $key ) ?>" />
+				<input type="hidden" name="two-factor-totp-key" value="<?php echo esc_attr( $key ); ?>" />
 				<label for="two-factor-totp-authcode">
 					<?php esc_html_e( 'Authentication Code:', 'two-factor' ); ?>
 					<input type="tel" name="two-factor-totp-authcode" id="two-factor-totp-authcode" class="input" value="" size="20" pattern="[0-9]*" />
@@ -195,7 +195,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	/**
 	 * Check if the TOTP secret key has a proper format.
 	 *
-	 * @param  string  $key TOTP secret key.
+	 * @param  string $key TOTP secret key.
 	 *
 	 * @return boolean
 	 */
@@ -243,7 +243,14 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	 * @return bool Whether the user gave a valid code
 	 */
 	public function validate_authentication( $user ) {
-		return $this->is_valid_authcode( $this->get_user_totp_key( $user->ID ), $_REQUEST['authcode'] );
+		if ( ! empty( $_REQUEST['authcode'] ) ) {
+			return $this->is_valid_authcode(
+				$this->get_user_totp_key( $user->ID ),
+			 	sanitize_text_field( $_REQUEST['authcode'] )
+			);
+		}
+
+		return false;
 	}
 
 	/**

--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -243,7 +243,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	 * @return bool Whether the user gave a valid code
 	 */
 	public function validate_authentication( $user ) {
-		if ( ! empty( $_REQUEST['authcode'] ) ) {
+		if ( ! empty( $_REQUEST['authcode'] ) ) { // WPCS: input var ok, nonce verified by login_form_validate_2fa().
 			return $this->is_valid_authcode(
 				$this->get_user_totp_key( $user->ID ),
 			 	sanitize_text_field( $_REQUEST['authcode'] )

--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -388,11 +388,14 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	 * Whether this Two Factor provider is configured and available for the user specified.
 	 *
 	 * @param WP_User $user WP_User object of the logged-in user.
+	 *
 	 * @return boolean
 	 */
 	public function is_available_for_user( $user ) {
 		// Only available if the secret key has been saved for the user.
-		return ! empty( $this->get_user_totp_key( $user->ID ) );
+		$key = $this->get_user_totp_key( $user->ID );
+
+		return ! empty( $key );
 	}
 
 	/**

--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -392,9 +392,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	 */
 	public function is_available_for_user( $user ) {
 		// Only available if the secret key has been saved for the user.
-		$key = get_user_meta( $user->ID, self::SECRET_META_KEY, true );
-
-		return ! empty( $key );
+		return ! empty( $this->get_user_totp_key( $user->ID ) );
 	}
 
 	/**

--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -246,7 +246,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		if ( ! empty( $_REQUEST['authcode'] ) ) { // WPCS: input var ok, nonce verified by login_form_validate_2fa().
 			return $this->is_valid_authcode(
 				$this->get_user_totp_key( $user->ID ),
-			 	sanitize_text_field( $_REQUEST['authcode'] )
+				sanitize_text_field( $_REQUEST['authcode'] ) // WPCS: input var ok, nonce verified by login_form_validate_2fa().
 			);
 		}
 

--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -71,27 +71,41 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		}
 
 		wp_nonce_field( 'user_two_factor_totp_options', '_nonce_user_two_factor_totp_options', false );
-		$key = get_user_meta( $user->ID, self::SECRET_META_KEY, true );
+
+		$key = $this->get_user_totp_key( $user->ID );
 		$this->admin_notices();
+
 		?>
-		<br />
+		<div id="two-factor-totp-options">
 		<?php if ( empty( $key ) ) :
 			$key = $this->generate_key();
 			$site_name = get_bloginfo( 'name', 'display' );
 			?>
-			<a href="javascript:;" onclick="jQuery('#two-factor-totp-options').toggle();"><?php esc_html_e( 'View Options &rarr;', 'two-factor' ); ?></a>
-			<div id="two-factor-totp-options" style="display:none;">
-					<img src="<?php echo esc_url( $this->get_google_qr_code( $site_name . ':' . $user->user_login, $key, $site_name ) ); ?>" id="two-factor-totp-qrcode" />
-					<p><strong><?php echo esc_html( $key ); ?></strong></p>
-					<p><?php esc_html_e( 'Please scan the QR code or manually enter the key, then enter an authentication code from your app in order to complete setup', 'two-factor' ); ?></p>
-					<p>
-						<label for="two-factor-totp-authcode"><?php esc_html_e( 'Authentication Code:', 'two-factor' ); ?></label>
-						<input type="hidden" name="two-factor-totp-key" value="<?php echo esc_attr( $key ) ?>" />
-						<input type="tel" name="two-factor-totp-authcode" id="two-factor-totp-authcode" class="input" value="" size="20" pattern="[0-9]*" />
-					</p>
-			</div>
+			<p>
+				<img src="<?php echo esc_url( $this->get_google_qr_code( $site_name . ':' . $user->user_login, $key, $site_name ) ); ?>" id="two-factor-totp-qrcode" />
+			</p>
+			<p>
+				<strong><?php echo esc_html( $key ); ?></strong>
+			</p>
+			<p>
+				<?php esc_html_e( 'Please scan the QR code or manually enter the key, then enter an authentication code from your app in order to complete setup', 'two-factor' ); ?>
+			</p>
+			<p>
+				<label for="two-factor-totp-authcode"><?php esc_html_e( 'Authentication Code:', 'two-factor' ); ?></label>
+				<input type="hidden" name="two-factor-totp-key" value="<?php echo esc_attr( $key ) ?>" />
+				<input type="tel" name="two-factor-totp-authcode" id="two-factor-totp-authcode" class="input" value="" size="20" pattern="[0-9]*" />
+				<input type="submit" class="button" name="two-factor-totp-submit" value="<?php esc_attr_e( 'Submit', 'two-factor' ); ?>" />
+			</p>
 		<?php else : ?>
-			<p class="success"><?php esc_html_e( 'Enabled', 'two-factor' ); ?></p>
+			<p class="success">
+				<?php esc_html_e( 'Secret key configured and registered.', 'two-factor' ); ?>
+			</p>
+			<p>
+				<input type="submit" class="button" name="two-factor-totp-delete" value="<?php esc_attr_e( 'Reset Key', 'two-factor' ); ?>" />
+				<em class="description">
+					<?php esc_html_e( 'You will have to re-scan the QR code on all devices as the previous codes will stop working.', 'two-factor' ); ?>
+				</em>
+			</p>
 		<?php endif; ?>
 		</div>
 		<?php
@@ -104,34 +118,93 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	 * @return false
 	 */
 	public function user_two_factor_options_update( $user_id ) {
+		$notices = array();
+		$errors = array();
+
+		$current_key = $this->get_user_totp_key( $user_id );
+
 		if ( isset( $_POST['_nonce_user_two_factor_totp_options'] ) ) {
 			check_admin_referer( 'user_two_factor_totp_options', '_nonce_user_two_factor_totp_options' );
 
-			$current_key = get_user_meta( $user_id, self::SECRET_META_KEY, true );
-			if ( $current_key && ! in_array( 'Two_Factor_Totp', Two_Factor_Core::get_enabled_providers_for_user( $user_id ), true ) ) {
-				delete_user_meta( $user_id, self::SECRET_META_KEY );
-				return;
-			} elseif ( ! isset( $_POST['two-factor-totp-key'] ) || $current_key === $_POST['two-factor-totp-key'] || ! preg_match( '/^[' . self::$_base_32_chars . ']+$/', $_POST['two-factor-totp-key'] ) ) {
-				// If the key hasn't changed or is invalid, do nothing.
-				return false;
+			// Delete the secret key.
+			if ( ! empty( $current_key ) && isset( $_POST['two-factor-totp-delete'] ) ) {
+				$this->delete_user_totp_key( $user_id );
 			}
 
-			$notices = array();
-
-			if ( ! empty( $_POST['two-factor-totp-authcode'] ) ) {
-				if ( $this->is_valid_authcode( $_POST['two-factor-totp-key'], $_POST['two-factor-totp-authcode'] ) ) {
-					if ( ! update_user_meta( $user_id, self::SECRET_META_KEY, $_POST['two-factor-totp-key'] ) ) {
-						$notices['error'][] = __( 'Unable to save Two Factor Authentication code. Please re-scan the QR code and enter the code provided by your application.', 'two-factor' );
+			// Validate and store a new secret key.
+			if ( ! empty( $_POST['two-factor-totp-authcode'] ) && ! empty( $_POST['two-factor-totp-key'] ) ) {
+				if ( $this->is_valid_key( $_POST['two-factor-totp-key'] ) ) {
+					if ( $this->is_valid_authcode( $_POST['two-factor-totp-key'], $_POST['two-factor-totp-authcode'] ) ) {
+						if ( ! $this->set_user_totp_key( $user_id, $key ) ) {
+							$errors[] = __( 'Unable to save Two Factor Authentication code. Please re-scan the QR code and enter the code provided by your application.', 'two-factor' );
+						}
+					} else {
+						$errors[] = __( 'Invalid Two Factor Authentication code.', 'two-factor' );
 					}
 				} else {
-					$notices['error'][] = __( 'Two Factor Authentication not activated, the authentication code you entered was not valid. Please re-scan the QR code and enter the code provided by your application.', 'two-factor' );
+					$errors[] = __( 'Invalid Two Factor Authentication secret key.', 'two-factor' );
 				}
+			}
+
+			if ( ! empty( $errors ) ) {
+				$notices['error'] = $errors;
 			}
 
 			if ( ! empty( $notices ) ) {
 				update_user_meta( $user_id, self::NOTICES_META_KEY, $notices );
 			}
 		}
+	}
+
+	/**
+	 * Get the TOTP secret key for a user.
+	 *
+	 * @param  int $user_id User ID.
+	 *
+	 * @return string
+	 */
+	public function get_user_totp_key( $user_id ) {
+		return (string) get_user_meta( $user_id, self::SECRET_META_KEY, true );
+	}
+
+	/**
+	 * Set the TOTP secret key for a user.
+	 *
+	 * @param int    $user_id User ID.
+	 * @param string $key TOTP secret key.
+	 *
+	 * @return boolean If the key was stored successfully.
+	 */
+	public function set_user_totp_key( $user_id, $key ) {
+		return update_user_meta( $user_id, self::SECRET_META_KEY, $key );
+	}
+
+	/**
+	 * Delete the TOTP secret key for a user.
+	 *
+	 * @param  int $user_id User ID.
+	 *
+	 * @return boolean If the key was deleted successfully.
+	 */
+	public function delete_user_totp_key( $user_id ) {
+		return delete_user_meta( $user_id, self::SECRET_META_KEY );
+	}
+
+	/**
+	 * Check if the TOTP secret key has a proper format.
+	 *
+	 * @param  string  $key TOTP secret key.
+	 *
+	 * @return boolean
+	 */
+	public function is_valid_key( $key ) {
+		$check = sprintf( '/^[%s]+$/', self::$_base_32_chars );
+
+		if ( 1 === preg_match( $check, $key ) ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**
@@ -168,9 +241,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	 * @return bool Whether the user gave a valid code
 	 */
 	public function validate_authentication( $user ) {
-		$key = get_user_meta( $user->ID, self::SECRET_META_KEY, true );
-
-		return $this->is_valid_authcode( $key, $_REQUEST['authcode'] );
+		return $this->is_valid_authcode( $this->get_user_totp_key( $user->ID ), $_REQUEST['authcode'] );
 	}
 
 	/**

--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -243,10 +243,10 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	 * @return bool Whether the user gave a valid code
 	 */
 	public function validate_authentication( $user ) {
-		if ( ! empty( $_REQUEST['authcode'] ) ) { // WPCS: input var ok, nonce verified by login_form_validate_2fa().
+		if ( ! empty( $_REQUEST['authcode'] ) ) { // WPCS: CSRF ok, nonce verified by login_form_validate_2fa().
 			return $this->is_valid_authcode(
 				$this->get_user_totp_key( $user->ID ),
-				sanitize_text_field( $_REQUEST['authcode'] ) // WPCS: input var ok, nonce verified by login_form_validate_2fa().
+				sanitize_text_field( $_REQUEST['authcode'] ) // WPCS: CSRF ok, nonce verified by login_form_validate_2fa().
 			);
 		}
 

--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -82,13 +82,13 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 			$site_name = get_bloginfo( 'name', 'display' );
 			?>
 			<p>
+				<?php esc_html_e( 'Please scan the QR code or manually enter the key, then enter an authentication code from your app in order to complete setup.', 'two-factor' ); ?>
+			</p>
+			<p>
 				<img src="<?php echo esc_url( $this->get_google_qr_code( $site_name . ':' . $user->user_login, $key, $site_name ) ); ?>" id="two-factor-totp-qrcode" />
 			</p>
 			<p>
 				<code><?php echo esc_html( $key ); ?></code>
-			</p>
-			<p>
-				<?php esc_html_e( 'Please scan the QR code or manually enter the key, then enter an authentication code from your app in order to complete setup.', 'two-factor' ); ?>
 			</p>
 			<p>
 				<input type="hidden" name="two-factor-totp-key" value="<?php echo esc_attr( $key ) ?>" />

--- a/tests/providers/class.two-factor-totp.php
+++ b/tests/providers/class.two-factor-totp.php
@@ -245,10 +245,10 @@ class Tests_Two_Factor_Totp extends WP_UnitTestCase {
 	 * @covers Two_Factor_Totp::is_valid_key
 	 */
 	public function test_is_valid_key() {
-		$this->assertTrue( $this->provider->is_valid_key( 'ABC123' ) );
-		$this->assertFalse( $this->provider->is_valid_key( '' ) );
-		$this->assertFalse( $this->provider->is_valid_key( 'abc123' ) );
-		$this->assertFalse( $this->provider->is_valid_key( 'has a space' ) );
+		$this->assertTrue( $this->provider->is_valid_key( 'ABC234' ), 'Base32 chars are valid' );
+		$this->assertFalse( $this->provider->is_valid_key( '' ), 'Empty string is invalid' );
+		$this->assertFalse( $this->provider->is_valid_key( 'abc233' ), 'Lowercase chars are invalid' );
+		$this->assertFalse( $this->provider->is_valid_key( 'has a space' ), 'Spaces not allowed' );
 	}
 
 	/**

--- a/tests/providers/class.two-factor-totp.php
+++ b/tests/providers/class.two-factor-totp.php
@@ -247,7 +247,11 @@ class Tests_Two_Factor_Totp extends WP_UnitTestCase {
 		);
 
 		// Configure the request and the nonce.
-		$_POST['_nonce_user_two_factor_totp_options'] = wp_create_nonce( 'user_two_factor_totp_options' );
+		$nonce = wp_create_nonce( 'user_two_factor_totp_options' );
+		$_POST['_nonce_user_two_factor_totp_options'] = $nonce;
+		$_REQUEST['_nonce_user_two_factor_totp_options'] = $nonce; // Required for check_admin_referer().
+
+		// Set the request to delete things.
 		$_POST['two-factor-totp-delete'] = 1;
 
 		// Process the request.

--- a/tests/providers/class.two-factor-totp.php
+++ b/tests/providers/class.two-factor-totp.php
@@ -251,4 +251,34 @@ class Tests_Two_Factor_Totp extends WP_UnitTestCase {
 		$this->assertFalse( $this->provider->is_valid_key( 'has a space' ) );
 	}
 
+	/**
+	 * @covers Two_Factor_Totp::user_two_factor_options_update
+	 */
+	public function test_user_can_delete_secret() {
+		$user = new WP_User( $this->factory->user->create() );
+		$key = $this->provider->generate_key();
+
+		// Configure secret for the user.
+		$this->provider->set_user_totp_key( $user->ID, $key );
+
+		$this->assertEquals(
+			$key,
+			$this->provider->get_user_totp_key( $user->ID ),
+			'Secret was stored and can be fetched'
+		);
+
+		// Configure the request and the nonce.
+		$_POST['_nonce_user_two_factor_totp_options'] = wp_create_nonce( 'user_two_factor_totp_options' );
+		$_POST['two-factor-totp-delete'] = 1;
+
+		// Process the request.
+		$this->provider->user_two_factor_options_update( $user->ID );
+
+		$this->assertEquals(
+			'',
+			$this->provider->get_user_totp_key( $user->ID ),
+			'Secret has been deleted'
+		);
+	}
+
 }

--- a/tests/providers/class.two-factor-totp.php
+++ b/tests/providers/class.two-factor-totp.php
@@ -208,4 +208,37 @@ class Tests_Two_Factor_Totp extends WP_UnitTestCase {
 		$this->assertTrue( $this->provider->is_valid_authcode( $key, $authcode ) );
 	}
 
+	/**
+	 * Check secret key CRUD operations.
+	 *
+	 * @covers Two_Factor_Totp::get_user_totp_key
+	 * @covers Two_Factor_Totp::set_user_totp_key
+	 * @covers Two_Factor_Totp::delete_user_totp_key
+	 */
+	public function test_user_totp_key() {
+		$user = new WP_User( $this->factory->user->create() );
+
+		$this->assertEquals(
+			'',
+			$this->provider->get_user_totp_key( $user->ID ),
+			'User does not have TOTP secret configured by default'
+		);
+
+		$this->provider->set_user_totp_key( $user->ID, '1234' );
+
+		$this->assertEquals(
+			'1234',
+			$this->provider->get_user_totp_key( $user->ID ),
+			'User has a secret key'
+		);
+
+		$this->provider->delete_user_totp_key( $user->ID );
+
+		$this->assertEquals(
+			'',
+			$this->provider->get_user_totp_key( $user->ID ),
+			'User no longer has a secret key stored'
+		);
+	}
+
 }

--- a/tests/providers/class.two-factor-totp.php
+++ b/tests/providers/class.two-factor-totp.php
@@ -79,27 +79,6 @@ class Tests_Two_Factor_Totp extends WP_UnitTestCase {
 	 * @covers Two_Factor_Totp::user_two_factor_options_update
 	 * @covers Two_Factor_Totp::is_available_for_user
 	 */
-	public function test_user_two_factor_options_update_no_key() {
-		$user = new WP_User( $this->factory->user->create() );
-
-		$request_key = '_nonce_user_two_factor_totp_options';
-		$_POST[$request_key] = wp_create_nonce( 'user_two_factor_totp_options' );
-		$_REQUEST[$request_key] = $_POST[$request_key];
-
-		ob_start();
-		$this->assertFalse( $this->provider->user_two_factor_options_update( $user->ID ) );
-		$content = ob_get_clean();
-
-		unset( $_REQUEST[$request_key] );
-		unset( $_POST[$request_key] );
-
-		$this->assertFalse( $this->provider->is_available_for_user( $user ) );
-	}
-
-	/**
-	 * @covers Two_Factor_Totp::user_two_factor_options_update
-	 * @covers Two_Factor_Totp::is_available_for_user
-	 */
 	public function test_user_two_factor_options_update_set_key_no_authcode() {
 		$user = new WP_User( $this->factory->user->create() );
 

--- a/tests/providers/class.two-factor-totp.php
+++ b/tests/providers/class.two-factor-totp.php
@@ -241,4 +241,14 @@ class Tests_Two_Factor_Totp extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @covers Two_Factor_Totp::is_valid_key
+	 */
+	public function test_is_valid_key() {
+		$this->assertTrue( $this->provider->is_valid_key( 'ABC123' ) );
+		$this->assertFalse( $this->provider->is_valid_key( '' ) );
+		$this->assertFalse( $this->provider->is_valid_key( 'abc123' ) );
+		$this->assertFalse( $this->provider->is_valid_key( 'has a space' ) );
+	}
+
 }


### PR DESCRIPTION
Fixes #138.

- [x] Introduce helpers for fetching, updating and deleting user TOTP secret keys.
- [x] Add a "Reset Key" button to remove a TOTP key from the user account.

<img width="1048" alt="reset-key-button" src="https://user-images.githubusercontent.com/169055/46084968-8cc4a280-c1ad-11e8-8c41-982ef7da11df.png">
