### PR TITLE
Fix a login issue on WP-Engine hosting

### DIFF
--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -318,6 +318,12 @@ class Two_Factor_Core {
 		$interim_login = isset( $_REQUEST['interim-login'] ); // WPCS: override ok.
 		$wp_login_url = wp_login_url();
 
+		// If we're running in a WP-Engine environment then we need to apply the
+		// site_url filter with the login_post scheme for the form action.
+		if ( function_exists( 'is_wpe' ) && is_wpe() ) {
+			$wp_login_url = apply_filters( 'site_url', $wp_login_url, null, 'login_post', null );
+		}
+
 		$rememberme = 0;
 		if ( isset( $_REQUEST['rememberme'] ) && $_REQUEST['rememberme'] ) {
 			$rememberme = 1;


### PR DESCRIPTION
WP-Engine requires additional parameters to exist on the URL for POST requests, and it applies those using a filter on the site_url hook when using the login_post scheme. So I've made sure to apply that filter when running in a WP-Engine environment.

Fixes #201