### PR TITLE
Login action URL

### DIFF
--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -378,9 +378,7 @@ class Two_Factor_Core {
 					</a>
 				</p>
 			</div>
-			<?php
-			elseif ( 1 < count( $backup_providers ) ) :
-			?>
+			<?php elseif ( 1 < count( $backup_providers ) ) : ?>
 			<div class="backup-methods-wrap">
 				<p class="backup-methods">
 					<a href="javascript:;" onclick="document.querySelector('ul.backup-methods').style.display = 'block';">

--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -367,11 +367,13 @@ class Two_Factor_Core {
 				<p class="backup-methods">
 					<a href="<?php echo esc_url( $login_url ); ?>">
 						<?php
-						echo esc_html( sprintf(
-							// translators: %s: Two-factor method name.
-							__( 'Or, use your backup method: %s &rarr;', 'two-factor' ),
-							$backup_provider->get_label()
-						) );
+						echo esc_html(
+							sprintf(
+								// translators: %s: Two-factor method name.
+								__( 'Or, use your backup method: %s &rarr;', 'two-factor' ),
+								$backup_provider->get_label()
+							)
+						);
 						?>
 					</a>
 				</p>
@@ -412,11 +414,13 @@ class Two_Factor_Core {
 		<p id="backtoblog">
 			<a href="<?php echo esc_url( home_url( '/' ) ); ?>" title="<?php esc_attr_e( 'Are you lost?', 'two-factor' ); ?>">
 				<?php
-				echo esc_html( sprintf(
-					// translators: %s: site name.
-					__( '&larr; Back to %s', 'two-factor' ),
-					get_bloginfo( 'title', 'display' )
-				) );
+				echo esc_html(
+					sprintf(
+						// translators: %s: site name.
+						__( '&larr; Back to %s', 'two-factor' ),
+						get_bloginfo( 'title', 'display' )
+					)
+				);
 				?>
 			</a>
 		</p>

--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -316,7 +316,6 @@ class Two_Factor_Core {
 		$available_providers = self::get_available_providers_for_user( $user );
 		$backup_providers = array_diff_key( $available_providers, array( $provider_class => null ) );
 		$interim_login = isset( $_REQUEST['interim-login'] ); // WPCS: override ok.
-		$wp_login_url = wp_login_url();
 
 		$rememberme = 0;
 		if ( isset( $_REQUEST['rememberme'] ) && $_REQUEST['rememberme'] ) {
@@ -335,7 +334,7 @@ class Two_Factor_Core {
 		}
 		?>
 
-		<form name="validate_2fa_form" id="loginform" action="<?php echo esc_url( set_url_scheme( add_query_arg( 'action', 'validate_2fa', $wp_login_url ), 'login_post' ) ); ?>" method="post" autocomplete="off">
+		<form name="validate_2fa_form" id="loginform" action="<?php echo esc_url( self::login_url( array( 'action' => 'validate_2fa' ) ) ); ?>" method="post" autocomplete="off">
 				<input type="hidden" name="provider"      id="provider"      value="<?php echo esc_attr( $provider_class ); ?>" />
 				<input type="hidden" name="wp-auth-id"    id="wp-auth-id"    value="<?php echo esc_attr( $user->ID ); ?>" />
 				<input type="hidden" name="wp-auth-nonce" id="wp-auth-nonce" value="<?php echo esc_attr( $login_nonce ); ?>" />
@@ -354,28 +353,28 @@ class Two_Factor_Core {
 			$backup_provider  = $backup_providers[ $backup_classname ];
 			?>
 			<div class="backup-methods-wrap">
-				<p class="backup-methods"><a href="<?php echo esc_url( add_query_arg( urlencode_deep( array(
+				<p class="backup-methods"><a href="<?php echo esc_url( self::login_url( array(
 					'action'        => 'backup_2fa',
 					'provider'      => $backup_classname,
 					'wp-auth-id'    => $user->ID,
 					'wp-auth-nonce' => $login_nonce,
 					'redirect_to'   => $redirect_to,
 					'rememberme'    => $rememberme,
-				) ), $wp_login_url ) ); ?>"><?php echo esc_html( sprintf( __( 'Or, use your backup method: %s &rarr;', 'two-factor' ), $backup_provider->get_label() ) ); ?></a></p>
+				) ) ); ?>"><?php echo esc_html( sprintf( __( 'Or, use your backup method: %s &rarr;', 'two-factor' ), $backup_provider->get_label() ) ); ?></a></p>
 			</div>
 		<?php elseif ( 1 < count( $backup_providers ) ) : ?>
 			<div class="backup-methods-wrap">
 				<p class="backup-methods"><a href="javascript:;" onclick="document.querySelector('ul.backup-methods').style.display = 'block';"><?php esc_html_e( 'Or, use a backup method…', 'two-factor' ); ?></a></p>
 				<ul class="backup-methods">
 					<?php foreach ( $backup_providers as $backup_classname => $backup_provider ) : ?>
-						<li><a href="<?php echo esc_url( add_query_arg( urlencode_deep( array(
+						<li><a href="<?php echo esc_url( self::login_url( array(
 							'action'        => 'backup_2fa',
 							'provider'      => $backup_classname,
 							'wp-auth-id'    => $user->ID,
 							'wp-auth-nonce' => $login_nonce,
 							'redirect_to'   => $redirect_to,
 							'rememberme'    => $rememberme,
-						) ), $wp_login_url ) ); ?>"><?php $backup_provider->print_label(); ?></a></li>
+						) ) ); ?>"><?php $backup_provider->print_label(); ?></a></li>
 					<?php endforeach; ?>
 				</ul>
 			</div>

--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -416,6 +416,23 @@ class Two_Factor_Core {
 	}
 
 	/**
+	 * Generate the form action login URL.
+	 *
+	 * @param  array  $params List of query argument pairs to add to the URL.
+	 *
+	 * @return string
+	 */
+	public static function login_url( $params = array() ) {
+		if ( ! is_array( $params ) ) {
+			$params = array();
+		}
+
+		$params = urlencode_deep( $params );
+
+		return add_query_arg( $params, site_url( 'wp-login.php', 'login_post' ) );
+	}
+
+	/**
 	 * Create the login nonce.
 	 *
 	 * @since 0.1-dev

--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -378,9 +378,9 @@ class Two_Factor_Core {
 					</a>
 				</p>
 			</div>
-		<?php
-		elseif ( 1 < count( $backup_providers ) ) :
-		?>
+			<?php
+			elseif ( 1 < count( $backup_providers ) ) :
+			?>
 			<div class="backup-methods-wrap">
 				<p class="backup-methods">
 					<a href="javascript:;" onclick="document.querySelector('ul.backup-methods').style.display = 'block';">

--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -315,7 +315,7 @@ class Two_Factor_Core {
 
 		$available_providers = self::get_available_providers_for_user( $user );
 		$backup_providers = array_diff_key( $available_providers, array( $provider_class => null ) );
-		$interim_login = isset( $_REQUEST['interim-login'] ); // WPCS: XSS ok.
+		$interim_login = isset( $_REQUEST['interim-login'] ); // WPCS: CSRF ok.
 
 		$rememberme = 0;
 		if ( isset( $_REQUEST['rememberme'] ) && $_REQUEST['rememberme'] ) {
@@ -351,15 +351,17 @@ class Two_Factor_Core {
 		<?php
 		if ( 1 === count( $backup_providers ) ) :
 			$backup_classname = key( $backup_providers );
-			$backup_provider  = $backup_providers[ $backup_classname ];
-			$login_url = self::login_url( array(
-				'action'        => 'backup_2fa',
-				'provider'      => $backup_classname,
-				'wp-auth-id'    => $user->ID,
-				'wp-auth-nonce' => $login_nonce,
-				'redirect_to'   => $redirect_to,
-				'rememberme'    => $rememberme,
-			) );
+			$backup_provider = $backup_providers[ $backup_classname ];
+			$login_url = self::login_url(
+				array(
+					'action'        => 'backup_2fa',
+					'provider'      => $backup_classname,
+					'wp-auth-id'    => $user->ID,
+					'wp-auth-nonce' => $login_nonce,
+					'redirect_to'   => $redirect_to,
+					'rememberme'    => $rememberme,
+				)
+			);
 			?>
 			<div class="backup-methods-wrap">
 				<p class="backup-methods">
@@ -386,14 +388,16 @@ class Two_Factor_Core {
 				<ul class="backup-methods">
 					<?php
 					foreach ( $backup_providers as $backup_classname => $backup_provider ) :
-						$login_url = self::login_url( array(
-							'action'        => 'backup_2fa',
-							'provider'      => $backup_classname,
-							'wp-auth-id'    => $user->ID,
-							'wp-auth-nonce' => $login_nonce,
-							'redirect_to'   => $redirect_to,
-							'rememberme'    => $rememberme,
-						) );
+						$login_url = self::login_url(
+							array(
+								'action'        => 'backup_2fa',
+								'provider'      => $backup_classname,
+								'wp-auth-id'    => $user->ID,
+								'wp-auth-nonce' => $login_nonce,
+								'redirect_to'   => $redirect_to,
+								'rememberme'    => $rememberme,
+							)
+						);
 						?>
 						<li>
 							<a href="<?php echo esc_url( $login_url ); ?>">
@@ -450,7 +454,7 @@ class Two_Factor_Core {
 	/**
 	 * Generate the form action login URL.
 	 *
-	 * @param  array  $params List of query argument pairs to add to the URL.
+	 * @param  array $params List of query argument pairs to add to the URL.
 	 *
 	 * @return string
 	 */

--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -458,7 +458,8 @@ class Two_Factor_Core {
 	/**
 	 * Generate the two-factor login form URL.
 	 *
-	 * @param  array $params List of query argument pairs to add to the URL.
+	 * @param  array  $params List of query argument pairs to add to the URL.
+	 * @param  string $scheme URL scheme context.
 	 *
 	 * @return string
 	 */

--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -334,7 +334,7 @@ class Two_Factor_Core {
 		}
 		?>
 
-		<form name="validate_2fa_form" id="loginform" action="<?php echo esc_url( self::login_url( array( 'action' => 'validate_2fa' ) ) ); ?>" method="post" autocomplete="off">
+		<form name="validate_2fa_form" id="loginform" action="<?php echo esc_url( self::login_url( array( 'action' => 'validate_2fa' ), 'login_post' ) ); ?>" method="post" autocomplete="off">
 				<input type="hidden" name="provider"      id="provider"      value="<?php echo esc_attr( $provider_class ); ?>" />
 				<input type="hidden" name="wp-auth-id"    id="wp-auth-id"    value="<?php echo esc_attr( $user->ID ); ?>" />
 				<input type="hidden" name="wp-auth-nonce" id="wp-auth-nonce" value="<?php echo esc_attr( $login_nonce ); ?>" />
@@ -452,20 +452,20 @@ class Two_Factor_Core {
 	}
 
 	/**
-	 * Generate the form action login URL.
+	 * Generate the two-factor login form URL.
 	 *
 	 * @param  array $params List of query argument pairs to add to the URL.
 	 *
 	 * @return string
 	 */
-	public static function login_url( $params = array() ) {
+	public static function login_url( $params = array(), $scheme = 'login' ) {
 		if ( ! is_array( $params ) ) {
 			$params = array();
 		}
 
 		$params = urlencode_deep( $params );
 
-		return add_query_arg( $params, site_url( 'wp-login.php', 'login_post' ) );
+		return add_query_arg( $params, site_url( 'wp-login.php', $scheme ) );
 	}
 
 	/**

--- a/tests/class.two-factor-core.php
+++ b/tests/class.two-factor-core.php
@@ -201,4 +201,11 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	public function test_is_user_using_two_factor_not_logged_in() {
 		$this->assertFalse( Two_Factor_Core::is_user_using_two_factor() );
 	}
+
+	/**
+	 * @covers Two_Factor_Core::login_url
+	 */
+	public function test_login_url() {
+		$this->assertContains( 'wp-login.php', Two_Factor_Core::login_url() );
+	}
 }

--- a/tests/class.two-factor-core.php
+++ b/tests/class.two-factor-core.php
@@ -207,5 +207,12 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	 */
 	public function test_login_url() {
 		$this->assertContains( 'wp-login.php', Two_Factor_Core::login_url() );
+
+		$this->assertContains(
+			'paramencoded=%2F%3D1',
+			Two_Factor_Core::login_url( array(
+				'paramencoded' => '/=1'
+			) )
+		);
 	}
 }


### PR DESCRIPTION
Fixes #256 and #257.

- Hardcodes the two-factor form action URL to `wp-login.php` (similar to [WP core](https://github.com/WordPress/WordPress/blob/da7a80d67fea29c2badfc538bfc01c8a585f0cbe/wp-login.php#L1082)) since all of the two-factor processing relies on [`login_form_{$action}` hooks](https://github.com/georgestephanis/two-factor/blob/99d654404d2bd908c710649bfc04a37274c23b6b/class.two-factor-core.php#L41-L42).

- Lots of WPCS fixes related to this simple change and the surrounding form HTML.

- Tested that this doesn't introduce regression with custom login forms outside `wp-login.php`, such as WooCommerce.