### PR TITLE
Release 0.3.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Enable Two-Factor Authentication using time-based one-time passwords (OTP, Googl
 **Contributors:** [georgestephanis](https://profiles.wordpress.org/georgestephanis), [valendesigns](https://profiles.wordpress.org/valendesigns), [stevenkword](https://profiles.wordpress.org/stevenkword), [extendwings](https://profiles.wordpress.org/extendwings), [sgrant](https://profiles.wordpress.org/sgrant), [aaroncampbell](https://profiles.wordpress.org/aaroncampbell), [johnbillion](https://profiles.wordpress.org/johnbillion), [stevegrunwell](https://profiles.wordpress.org/stevegrunwell), [netweb](https://profiles.wordpress.org/netweb), [kasparsd](https://profiles.wordpress.org/kasparsd)  
 **Tags:** [two factor](https://wordpress.org/plugins/tags/two-factor), [two step](https://wordpress.org/plugins/tags/two-step), [authentication](https://wordpress.org/plugins/tags/authentication), [login](https://wordpress.org/plugins/tags/login), [totp](https://wordpress.org/plugins/tags/totp), [fido u2f](https://wordpress.org/plugins/tags/fido-u2f), [u2f](https://wordpress.org/plugins/tags/u2f), [email](https://wordpress.org/plugins/tags/email), [backup codes](https://wordpress.org/plugins/tags/backup-codes), [2fa](https://wordpress.org/plugins/tags/2fa), [yubikey](https://wordpress.org/plugins/tags/yubikey)  
 **Requires at least:** 4.3  
-**Tested up to:** 4.9.8  
+**Tested up to:** 5.0  
 **Stable tag:** trunk (master)  
 
 [![Build Status](https://travis-ci.org/georgestephanis/two-factor.svg?branch=master)](https://travis-ci.org/georgestephanis/two-factor) [![Coverage Status](https://coveralls.io/repos/georgestephanis/two-factor/badge.svg?branch=master)](https://coveralls.io/github/georgestephanis/two-factor) [![Built with Grunt](https://cdn.gruntjs.com/builtwith.svg)](http://gruntjs.com) 
@@ -29,5 +29,5 @@ Then open [a pull request](https://help.github.com/articles/creating-a-pull-requ
 
 ## Changelog ##
 
-See: [https://github.com/georgestephanis/two-factor/commits/master](https://github.com/georgestephanis/two-factor/commits/master)
+See the [release history](https://github.com/georgestephanis/two-factor/releases).
 

--- a/readme.txt
+++ b/readme.txt
@@ -24,4 +24,4 @@ Then open [a pull request](https://help.github.com/articles/creating-a-pull-requ
 
 == Changelog ==
 
-See: [https://github.com/georgestephanis/two-factor/commits/master](https://github.com/georgestephanis/two-factor/commits/master)
+See the [release history](https://github.com/georgestephanis/two-factor/releases).

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: georgestephanis, valendesigns, stevenkword, extendwings, sgrant, aaroncampbell, johnbillion, stevegrunwell, netweb, kasparsd
 Tags: two factor, two step, authentication, login, totp, fido u2f, u2f, email, backup codes, 2fa, yubikey
 Requires at least: 4.3
-Tested up to: 4.9.8
+Tested up to: 5.0
 Stable tag: trunk
 
 Enable Two-Factor Authentication using time-based one-time passwords (OTP, Google Authenticator), Universal 2nd Factor (FIDO U2F, YubiKey), email and backup verification codes.

--- a/two-factor.php
+++ b/two-factor.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Two Factor
- * Plugin URI: https://github.com/georgestephanis/two-factor/
+ * Plugin URI: https://wordpress.org/plugins/two-factor/
  * Description: A prototype extensible core to enable Two-Factor Authentication.
  * Author: George Stephanis
  * Version: 0.3.0

--- a/two-factor.php
+++ b/two-factor.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/georgestephanis/two-factor/
  * Description: A prototype extensible core to enable Two-Factor Authentication.
  * Author: George Stephanis
- * Version: 0.2.0
+ * Version: 0.3.0
  * Author URI: https://stephanis.info
  * Network: True
  * Text Domain: two-factor


### PR DESCRIPTION
- Mark as tested with WordPress 5.0.

- Always post the two-factor login form to `wp-login.php` which runs all the required hooks for processing. Fixes login issues on WP Engine #257 and when a custom login URL is used #256.