### PR TITLE
remove unnecessary console.log

### DIFF
--- a/providers/js/fido-u2f-admin.js
+++ b/providers/js/fido-u2f-admin.js
@@ -15,8 +15,6 @@
 			return false;
 		}
 
-		window.console.log( 'sign', u2fL10n.register.request );
-
 		$( this ).prop( 'disabled', true );
 		$( '.register-security-key .spinner' ).addClass( 'is-active' );
 		$statusNotice.text( '' );
@@ -31,8 +29,6 @@
 			$button.prop( 'disabled', false );
 
 			if ( data.errorCode ) {
-				window.console.log( 'Registration Failed', data.errorCode );
-
 				if ( u2fL10n.text.error_codes[ data.errorCode ] ) {
 					$statusNotice.text( u2fL10n.text.error_codes[ data.errorCode ] );
 				} else {

--- a/providers/js/fido-u2f-login.js
+++ b/providers/js/fido-u2f-login.js
@@ -1,17 +1,13 @@
 /* global u2f, u2fL10n */
 ( function( $ ) {
 	if ( ! window.u2fL10n ) {
-		window.console.log( 'u2fL10n is not defined' );
+		window.console.error( 'u2fL10n is not defined' );
 		return;
 	}
 
-	window.console.log( 'sign', u2fL10n.request );
-
 	u2f.sign( u2fL10n.request[0].appId, u2fL10n.request[0].challenge, u2fL10n.request, function( data ) {
-		window.console.log( 'Authenticate callback', data );
-
 		if ( data.errorCode ) {
-			window.console.log( 'Registration Failed', data.errorCode );
+			window.console.error( 'Registration Failed', data.errorCode );
 		} else {
 			$( '#u2f_response' ).val( JSON.stringify( data ) );
 			$( '#loginform' ).submit();


### PR DESCRIPTION
Fixes #262.

* remove unnecessary console.log
* remove console.error that are output to the user via a normal error message to avoid duplicate error notifications
* change console.log to .error when no error is output to user