### PR TITLE
Fix Jetpack SSO Compatibility

### DIFF
--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -307,7 +307,7 @@ class Two_Factor_Core {
 			wp_die( esc_html__( 'Failed to create a login nonce.', 'two-factor' ) );
 		}
 
-		$redirect_to = isset( $_REQUEST['redirect_to'] ) ? $_REQUEST['redirect_to'] : $_SERVER['REQUEST_URI'];
+		$redirect_to = isset( $_REQUEST['redirect_to'] ) ? $_REQUEST['redirect_to'] : admin_url();
 
 		self::login_html( $user, $login_nonce['key'], $redirect_to );
 	}


### PR DESCRIPTION
After SSO, we successfully see the two factor verification. The problem is that the query string for SSO is like `?action=jetpack-sso&result=success&user_id=<redacted>&sso_nonce=<redacted>`. If we try to redirect back to that page, we get into a loop where SSO tries to login again, even though we're already logged in (and the nonce is no longer valid). We can redirect to /wp-admin/ instead of `REQEUST_URI`.