### PR TITLE
Fix U2F feature detection in Firefox

### DIFF
--- a/includes/Google/u2f-api.js
+++ b/includes/Google/u2f-api.js
@@ -17,12 +17,6 @@
 var u2f = u2f || {};
 
 /**
- * Check if browser supports U2F API before this wrapper was added.
- * @type {int}
- */
-u2f.HasNativeApiSupport = ( ( u2f && u2f.register ) || ( chrome && chrome.runtime ) );
-
-/**
  * FIDO U2F Javascript API Version
  * @number
  */

--- a/providers/class.two-factor-fido-u2f-admin.php
+++ b/providers/class.two-factor-fido-u2f-admin.php
@@ -65,14 +65,14 @@ class Two_Factor_FIDO_U2F_Admin {
 			'fido-u2f-admin',
 			plugins_url( 'css/fido-u2f-admin.css', __FILE__ ),
 			null,
-			Two_Factor_FIDO_U2F::asset_version()
+			self::asset_version()
 		);
 
 		wp_enqueue_script(
 			'fido-u2f-admin',
 			plugins_url( 'js/fido-u2f-admin.js', __FILE__ ),
 			array( 'jquery', 'fido-u2f-api' ),
-			Two_Factor_FIDO_U2F::asset_version(),
+			self::asset_version(),
 			true
 		);
 
@@ -115,7 +115,7 @@ class Two_Factor_FIDO_U2F_Admin {
 			'inline-edit-key',
 			plugins_url( 'js/fido-u2f-admin-inline-edit.js', __FILE__ ),
 			array( 'jquery' ),
-			'0.1.0-dev.1',
+			self::asset_version(),
 			true
 		);
 
@@ -126,6 +126,18 @@ class Two_Factor_FIDO_U2F_Admin {
 				'error' => esc_html__( 'Error while saving the changes.', 'two-factor' ),
 			)
 		);
+	}
+
+	/**
+	 * Return the current asset version number.
+	 *
+	 * Added as own helper to allow swapping the implementation once we inject
+	 * it as a dependency.
+	 *
+	 * @return string
+	 */
+	protected static function asset_version() {
+		return Two_Factor_FIDO_U2F::asset_version();
 	}
 
 	/**

--- a/providers/class.two-factor-fido-u2f-admin.php
+++ b/providers/class.two-factor-fido-u2f-admin.php
@@ -65,14 +65,14 @@ class Two_Factor_FIDO_U2F_Admin {
 			'fido-u2f-admin',
 			plugins_url( 'css/fido-u2f-admin.css', __FILE__ ),
 			null,
-			'0.1.0-dev.1'
+			Two_Factor_FIDO_U2F::asset_version()
 		);
 
 		wp_enqueue_script(
 			'fido-u2f-admin',
 			plugins_url( 'js/fido-u2f-admin.js', __FILE__ ),
 			array( 'jquery', 'fido-u2f-api' ),
-			'0.1.0-dev.3',
+			Two_Factor_FIDO_U2F::asset_version(),
 			true
 		);
 

--- a/providers/class.two-factor-fido-u2f-admin.php
+++ b/providers/class.two-factor-fido-u2f-admin.php
@@ -97,7 +97,7 @@ class Two_Factor_FIDO_U2F_Admin {
 					4 => esc_html__( 'U2F device ineligible.', 'two-factor' ),
 					5 => esc_html__( 'U2F request timeout reached.', 'two-factor' ),
 				),
-				'u2f_not_supported' => esc_html__( 'FIDO U2F is not supported in your web browser. Try using Google Chrome.', 'two-factor' ),
+				'u2f_not_supported' => esc_html__( 'FIDO U2F appears to be not supported by your web browser. Try using Google Chrome or Firefox.', 'two-factor' ),
 			),
 		);
 

--- a/providers/class.two-factor-fido-u2f.php
+++ b/providers/class.two-factor-fido-u2f.php
@@ -30,14 +30,11 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 	const AUTH_DATA_USER_META_KEY = '_two_factor_fido_u2f_login_request';
 
 	/**
-	 * Version number for the bundled JS scripts.
-	 *
-	 * Bump this whenever you update the javascript files to bust the static
-	 * file cache.
+	 * Version number for the bundled assets.
 	 *
 	 * @var string
 	 */
-	const JS_VERSION = '0.2.0';
+	const U2F_ASSET_VERSION = '0.2.0';
 
 	/**
 	 * Ensures only one instance of this class exists in memory at any one time.
@@ -74,7 +71,7 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 			'fido-u2f-api',
 			plugins_url( 'includes/Google/u2f-api.js', dirname( __FILE__ ) ),
 			null,
-			self::JS_VERSION,
+			self::asset_version(),
 			true
 		);
 
@@ -82,13 +79,24 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 			'fido-u2f-login',
 			plugins_url( 'js/fido-u2f-login.js', __FILE__ ),
 			array( 'jquery', 'fido-u2f-api' ),
-			self::JS_VERSION,
+			self::asset_version(),
 			true
 		);
 
 		add_action( 'two-factor-user-options-' . __CLASS__, array( $this, 'user_options' ) );
 
 		return parent::__construct();
+	}
+
+	/**
+	 * Get the asset version number.
+	 *
+	 * TODO: There should be a plugin-level helper for getting the current plugin version.
+	 *
+	 * @return string
+	 */
+	public static function asset_version() {
+		return self::U2F_ASSET_VERSION;
 	}
 
 	/**

--- a/providers/class.two-factor-fido-u2f.php
+++ b/providers/class.two-factor-fido-u2f.php
@@ -30,6 +30,16 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 	const AUTH_DATA_USER_META_KEY = '_two_factor_fido_u2f_login_request';
 
 	/**
+	 * Version number for the bundled JS scripts.
+	 *
+	 * Bump this whenever you update the javascript files to bust the static
+	 * file cache.
+	 *
+	 * @var string
+	 */
+	const JS_VERSION = '0.2.0';
+
+	/**
 	 * Ensures only one instance of this class exists in memory at any one time.
 	 *
 	 * @return \Two_Factor_FIDO_U2F
@@ -64,7 +74,7 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 			'fido-u2f-api',
 			plugins_url( 'includes/Google/u2f-api.js', dirname( __FILE__ ) ),
 			null,
-			'0.1.0-dev.2',
+			self::JS_VERSION,
 			true
 		);
 
@@ -72,7 +82,7 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 			'fido-u2f-login',
 			plugins_url( 'js/fido-u2f-login.js', __FILE__ ),
 			array( 'jquery', 'fido-u2f-api' ),
-			'0.1.0-dev.2',
+			self::JS_VERSION,
 			true
 		);
 

--- a/providers/js/fido-u2f-admin.js
+++ b/providers/js/fido-u2f-admin.js
@@ -2,7 +2,7 @@
 ( function( $ ) {
 	var $button = $( '#register_security_key' );
 	var $statusNotice = $( '#security-keys-section .security-key-status' );
-	var u2fSupported = ( u2f && u2f.HasNativeApiSupport );
+	var u2fSupported = ( window.u2f && 'register' in window.u2f );
 
 	if ( ! u2fSupported ) {
 		$statusNotice.text( u2fL10n.text.u2f_not_supported );
@@ -24,7 +24,7 @@
 			challenge: u2fL10n.register.request.challenge
 		};
 
-		u2f.register( u2fL10n.register.request.appId, [ registerRequest ], u2fL10n.register.sigs, function( data ) {
+		window.u2f.register( u2fL10n.register.request.appId, [ registerRequest ], u2fL10n.register.sigs, function( data ) {
 			$( '.register-security-key .spinner' ).removeClass( 'is-active' );
 			$button.prop( 'disabled', false );
 


### PR DESCRIPTION
- [x] Fix U2F feature detection in Firefox where `window.u2f` is ready-only now. Move the check to the registration logic instead.
- [x] Introduce a new constant to represent the version number of all U2F related JS and CSS files.