### PR TITLE
Add two_factor_totp_title filter to allow TOTP title to be changed by site-owner

### DIFF
--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -80,12 +80,13 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		<?php if ( empty( $key ) ) :
 			$key = $this->generate_key();
 			$site_name = get_bloginfo( 'name', 'display' );
+			$totp_title = apply_filters( 'two_factor_totp_title', $site_name . ':' . $user->user_login, $key );
 			?>
 			<p>
 				<?php esc_html_e( 'Please scan the QR code or manually enter the key, then enter an authentication code from your app in order to complete setup.', 'two-factor' ); ?>
 			</p>
 			<p>
-				<img src="<?php echo esc_url( $this->get_google_qr_code( $site_name . ':' . $user->user_login, $key, $site_name ) ); ?>" id="two-factor-totp-qrcode" />
+				<img src="<?php echo esc_url( $this->get_google_qr_code( totp_title, $key, $site_name ) ); ?>" id="two-factor-totp-qrcode" />
 			</p>
 			<p>
 				<code><?php echo esc_html( $key ); ?></code>

--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -80,13 +80,13 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		<?php if ( empty( $key ) ) :
 			$key = $this->generate_key();
 			$site_name = get_bloginfo( 'name', 'display' );
-			$totp_title = apply_filters( 'two_factor_totp_title', $site_name . ':' . $user->user_login, $key );
+			$totp_title = apply_filters( 'two_factor_totp_title', $site_name . ':' . $user->user_login );
 			?>
 			<p>
 				<?php esc_html_e( 'Please scan the QR code or manually enter the key, then enter an authentication code from your app in order to complete setup.', 'two-factor' ); ?>
 			</p>
 			<p>
-				<img src="<?php echo esc_url( $this->get_google_qr_code( totp_title, $key, $site_name ) ); ?>" id="two-factor-totp-qrcode" />
+				<img src="<?php echo esc_url( $this->get_google_qr_code( $totp_title, $key, $site_name ) ); ?>" id="two-factor-totp-qrcode" />
 			</p>
 			<p>
 				<code><?php echo esc_html( $key ); ?></code>

--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -80,7 +80,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		<?php if ( empty( $key ) ) :
 			$key = $this->generate_key();
 			$site_name = get_bloginfo( 'name', 'display' );
-			$totp_title = apply_filters( 'two_factor_totp_title', $site_name . ':' . $user->user_login );
+			$totp_title = apply_filters( 'two_factor_totp_title', $site_name . ':' . $user->user_login, $user );
 			?>
 			<p>
 				<?php esc_html_e( 'Please scan the QR code or manually enter the key, then enter an authentication code from your app in order to complete setup.', 'two-factor' ); ?>


### PR DESCRIPTION
This PR adds the `two_factor_totp_title` filter which allows the TOTP code to be filtered by a site owner. 

Example usage:

```
function my_totp_title(){
        return 'My Website';
}
add_filter( 'two_factor_totp_title', 'my_totp_title' );
```

Testing:
Add the filter to a feature plugin or your theme's `functions.php` file then re-add the QR code. 

Fixes #291